### PR TITLE
Add MatchedPath

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::env::{current_dir, Args};
+use std::env::Args;
 use std::io::Write;
 use std::process::exit;
 
@@ -11,10 +11,11 @@ pub fn entrypoint(args: &mut Args) -> Result<()> {
         .expect("The first argument is supposed to be a program name.");
     match args.next() {
         Some(query) => {
-            let finder = Finder::new(current_dir()?, &query)?;
+            // TODO: Receive path from the cli args
+            let finder = Finder::new(".", &query)?;
             for path in finder {
                 let path = path?;
-                println!("{}", path.to_string_lossy()); // FIXME: Implement more appropriately, plus sorting is required.
+                println!("{}", path); // FIXME: Implement more appropriately, plus sorting is required.
             }
             Ok(())
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub type Result<T> = StdResult<T, Error>;
 #[derive(Debug)]
 pub enum ErrorKind {
     InsufficientQuery,
+    InvalidUnicode,
     IO,
 }
 
@@ -38,6 +39,15 @@ impl Error {
         Self {
             message: message.to_string(),
             kind: ErrorKind::InsufficientQuery,
+            source: None,
+            exit_code: FAILURE,
+        }
+    }
+
+    pub fn invalid_unicode(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            kind: ErrorKind::InvalidUnicode,
             source: None,
             exit_code: FAILURE,
         }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -1,31 +1,35 @@
 use std::collections::VecDeque;
+use std::fmt::{self, Display, Formatter};
 use std::fs::ReadDir;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::error::{Error, Result};
 
 pub struct Finder {
-    root: PathBuf,
-    dirs: VecDeque<ReadDir>,
+    root: String,
     query: String,
+    dirs: VecDeque<ReadDir>,
 }
 
 impl Finder {
     pub fn new(dir: impl AsRef<Path>, query: &str) -> Result<Self> {
-        let root = dir.as_ref();
+        let root = dir.as_ref().canonicalize()?;
         let mut dirs = VecDeque::new();
         let read_dir = root.read_dir()?;
         dirs.push_back(read_dir);
+        let root = root.to_str().ok_or(Error::invalid_unicode(
+            "The passed directory does not seem to valid unicode.",
+        ))?;
         Ok(Self {
-            root: root.to_path_buf(),
-            dirs,
+            root: root.to_string(),
             query: query.to_string(),
+            dirs,
         })
     }
 }
 
 impl Iterator for Finder {
-    type Item = Result<PathBuf>; // TODO
+    type Item = Result<MatchedPath>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let dir = self.dirs.front_mut()?;
@@ -42,6 +46,7 @@ impl Iterator for Finder {
             Ok(path) => path,
             Err(e) => return Some(Err(Error::from(e))),
         };
+        assert!(path.is_absolute()); // TODO: Remove later
         if path.is_dir() {
             match path.read_dir() {
                 Ok(dir) => {
@@ -51,8 +56,51 @@ impl Iterator for Finder {
                 Err(e) => Some(Err(Error::from(e))),
             }
         } else {
-            // TODO: Filter with query
-            Some(Ok(path))
+            match MatchedPath::new(&self.query, &self.root, &path) {
+                Some(matched) => Some(Ok(matched)),
+                None => self.next(),
+            }
         }
     }
+}
+
+#[derive(Debug)]
+pub struct MatchedPath {
+    absolute: String,
+    relative: String,
+    positions: Vec<usize>,
+}
+
+impl Display for MatchedPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.relative, f)
+    }
+}
+
+impl MatchedPath {
+    pub(super) fn new(query: &str, root: &str, path: &Path) -> Option<Self> {
+        let absolute = path.to_str()?;
+        let relative = absolute
+            .strip_prefix(root)
+            .expect("The passed root must be prefix of the path.");
+        let relative = &relative[1..]; // NOTE: Delete the prefix of slash
+        let mut positions: Vec<usize> = vec![];
+        for char in query.chars() {
+            let begin = if let Some(pos) = positions.last() {
+                pos + 1
+            } else {
+                0
+            };
+            // TODO: Explain this line later.
+            let target = &relative[begin..].to_lowercase();
+            let pos = target.find(char)?;
+            positions.push(begin + pos);
+        }
+        Some(Self {
+            absolute: absolute.to_string(),
+            relative: relative.to_string(),
+            positions,
+        })
+    }
+    // TODO: Present with colorized value with emphasized positions.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub use cli::entrypoint;
 pub use cli::safe_exit;
 pub use error::{Error, ErrorKind, Result};
-pub use finder::Finder;
+pub use finder::{Finder, MatchedPath};
 
 mod cli;
 mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ use pinpoint::{entrypoint, safe_exit};
 fn main() {
     match entrypoint(&mut env::args()) {
         Ok(_) => safe_exit(0),
-        Err(e) => safe_exit(e.exit_code),
+        Err(e) => {
+            eprintln!("Something happened: {:?}", e); // TODO: Write a more readable error message.
+            safe_exit(e.exit_code);
+        }
     }
 }

--- a/tests/finder_test.rs
+++ b/tests/finder_test.rs
@@ -1,7 +1,4 @@
-use std::env::current_dir;
-use std::path::PathBuf;
-
-use pinpoint::{Finder, Result};
+use pinpoint::{Finder, MatchedPath, Result};
 
 use crate::helper::create_tree;
 
@@ -10,7 +7,9 @@ mod helper;
 #[test]
 fn returns_all_paths() {
     let dir = create_tree().unwrap();
-    let mut finder = Finder::new(dir.path(), "").unwrap();
-    let size = finder.collect::<Vec<Result<PathBuf>>>().len();
+    let finder = Finder::new(dir.path(), "").unwrap();
+    let size = finder.collect::<Vec<Result<MatchedPath>>>().len();
     assert_eq!(size, 27);
 }
+
+// TODO: Test more

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -1,6 +1,5 @@
 use std::fs::{create_dir_all, File};
 use std::io;
-use std::path::PathBuf;
 
 use tempfile::{tempdir, TempDir};
 


### PR DESCRIPTION
`MatchedPath` is responsible for representing what kind of path is
matched. This struct will have exactness of its match; if its positions
are all contiguous, this is exactly matched string.