### PR TITLE
Disable Clippy on super-linter and run it on our own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
+          components: rustfmt, clippy
+
+      - run: cargo fmt -- --check
+
+      - run: cargo clippy
 
       - run: cargo test
 
@@ -35,3 +40,4 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_RUST_CLIPPY: false


### PR DESCRIPTION
As [I said](https://github.com/yykamei/pinpoint/pull/11#issuecomment-843580592), clippy on super-linter is [flaky](https://github.com/yykamei/pinpoint/runs/2614474777?check_suite_focus=true), so I want to run it by myself.

By the way, I still keep super-linter for other tools, such as markdownlint.