### PR TITLE
Stop recursion to avoid stack overflow

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,7 +131,6 @@ fn output_on_terminal(
         cursor::SavePosition,
         cursor::MoveToNextLine(1),
     )?;
-    std::fs::File::create("/tmp/ok.txt")?.write_all(format!("{:?}", paths).as_bytes())?;
     for (idx, path) in paths.iter().enumerate() {
         let idx = idx as u16;
         let prefix = if idx == selection { "> " } else { "  " };
@@ -147,7 +146,8 @@ fn output_on_terminal(
 }
 
 fn find_paths(starting_point: &str, query: &str, limit: u16) -> Result<Vec<MatchedPath>> {
-    let mut paths = vec![];
+    let mut paths = Vec::with_capacity(100); // TODO: Tune this capacity later.
+
     // TODO: Sort
     for path in Finder::new(starting_point, query)?.take(limit.into()) {
         let path = path?;


### PR DESCRIPTION
`cargo run` can cause stack overflow because of `Finder`'s recursion.
This patch stops recursion and used `loop`.

Note this PR will be readable with `--ignore-all-space`.