### PR TITLE
Rename the project to thwack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,14 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pinpoint"
-version = "0.1.0"
-dependencies = [
- "crossterm",
- "tempfile",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +251,14 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "thwack"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pinpoint"
+name = "thwack"
 version = "0.1.0"
 authors = ["Yutaka Kamei <kamei@yykamei.me>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# pinpoint
+# thwack
 Command line version of Go To File utility, similar to the one on GitHub

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,11 +3,11 @@ use std::env::ArgsOs;
 use crate::error::{Error, Result};
 
 // TODO: --no-exec? might be required; users sometimes want to execute the file itself.
-pub(crate) const HELP: &str = "pinpoint
+pub(crate) const HELP: &str = "thwack
 Find a file and open it with an arbitrary command.
 
 USAGE:
-    pinpoint [OPTIONS] [query]
+    thwack [OPTIONS] [query]
 
 ARGS:
     <query>                   The name of the file you'd like to find

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::io::{stderr, stdout};
 
-use pinpoint::{entrypoint, safe_exit};
+use thwack::{entrypoint, safe_exit};
 
 fn main() {
     let mut out = stdout();

--- a/tests/finder_test.rs
+++ b/tests/finder_test.rs
@@ -1,4 +1,4 @@
-use pinpoint::Finder;
+use thwack::Finder;
 
 use crate::helper::create_tree;
 


### PR DESCRIPTION
Previously, this project was `pinpoint`, but its namesake has already
existed on crates.io.

So, I decided to rename it with a new name, `thwack`.