### PR TITLE
Update dependabot.yml to ignore patch and minor updates on actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
       interval: daily
       time: "12:20"
       timezone: Asia/Tokyo
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore

> Dependabot version updates now have the ability to ignore major, minor, or patch updates for a specific dependency or set of dependencies.

🎉 

