### PR TITLE
Add Changelog action to automatically update

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: get_project
-        run: echo "::set-output name=${GITHUB_REPOSITORY#*/}"
+        run: echo "::set-output name=project::${GITHUB_REPOSITORY#*/}"
       - uses: actions/checkout@v2
       - uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
         with:
-          args: '--user ${{ github.repository_owner }} --project ${{ steps.get_project.outputs.name }} --exclude-labels chore,duplicate,question,invalid,wontfix'
+          args: '--user ${{ github.repository_owner }} --project ${{ steps.get_project.outputs.project }} --exclude-labels chore,duplicate,question,invalid,wontfix'
         env:
           CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: Changelog
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - id: get_project
+        run: echo "::set-output name=${GITHUB_REPOSITORY#*/}"
+      - uses: actions/checkout@v2
+      - uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
+        with:
+          args: '--user ${{ github.repository_owner }} --project ${{ steps.get_project.outputs.name }} --exclude-labels chore,duplicate,question,invalid,wontfix'
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          changes=$(git status --short | wc -l)
+          if [[ "$changes" -z ]]; then
+            exit 0
+          fi
+          git checkout -b "update-changelog/$(date +%s)"
+          git add -A
+          git commit -m 'Update CHANGELOG.md'
+          cat <<BODY > body.txt
+          *This pull request was automatically created to make CHANGELOG.md the latest*.
+
+          Check the files changes, and merge if the changes make sense.
+          BODY
+          gh pr create --title 'Update CHANGELOG.md' --body-file body.txt --label chore
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,7 +31,7 @@ jobs:
           cat <<BODY > body.txt
           *This pull request was automatically created to make CHANGELOG.md the latest*.
 
-          Check the files changes, and merge if the changes make sense.
+          Check the files changes and merge if the changes make sense.
           BODY
           gh pr create --head "$branch" --title 'Update CHANGELOG.md' --body-file body.txt --label chore
         env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,9 +22,10 @@ jobs:
           if [[ -z "$changes" ]]; then
             exit 0
           fi
+          branch="update-changelog/$(date +%s)"
           git config user.email "noreply@github.com"
           git config user.name "GitHub"
-          git checkout -b "update-changelog/$(date +%s)"
+          git checkout -b "$branch"
           git add -A
           git commit -m 'Update CHANGELOG.md'
           cat <<BODY > body.txt
@@ -32,6 +33,6 @@ jobs:
 
           Check the files changes, and merge if the changes make sense.
           BODY
-          gh pr create --title 'Update CHANGELOG.md' --body-file body.txt --label chore
+          gh pr create --head "$branch" --title 'Update CHANGELOG.md' --body-file body.txt --label chore
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,6 +22,8 @@ jobs:
           if [[ -z "$changes" ]]; then
             exit 0
           fi
+          git config user.email "noreply@github.com"
+          git config user.name "GitHub"
           git checkout -b "update-changelog/$(date +%s)"
           git add -A
           git commit -m 'Update CHANGELOG.md'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
           CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           changes=$(git status --short | wc -l)
-          if [[ "$changes" -z ]]; then
+          if [[ -z "$changes" ]]; then
             exit 0
           fi
           git checkout -b "update-changelog/$(date +%s)"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - changelog-action
   workflow_dispatch:
 jobs:
   changelog:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - changelog-action
   workflow_dispatch:
 jobs:
   changelog:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,6 +28,7 @@ jobs:
           git checkout -b "$branch"
           git add -A
           git commit -m 'Update CHANGELOG.md'
+          git push origin "$branch"
           cat <<BODY > body.txt
           *This pull request was automatically created to make CHANGELOG.md the latest*.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,9 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_note:
+        description: Release Note
+        required: false
+jobs:
+  release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,0 @@
-name: Release
-on:
-  workflow_dispatch:
-    inputs:
-      release_note:
-        description: Release Note
-        required: false
-jobs:
-  release:


### PR DESCRIPTION
This is a part of #21.

A changelog should be always updated when the default branch gets updated. This new workflow will get triggered on the `push` event on the default branch of this repository. To test the functionality, I added the `workflow_dispatch` event as well.