### PR TITLE
Implement Ord for MatchedPath

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,8 @@ use crossterm::{
 use crate::args::{Parser, HELP};
 use crate::error::Result;
 use crate::finder::Finder;
-use crate::{Error, MatchedPath};
+use crate::matched_path::MatchedPath;
+use crate::Error;
 
 pub fn safe_exit(code: i32, stdout: Stdout, stderr: Stderr) {
     let _ = stdout.lock().flush();
@@ -168,12 +169,14 @@ fn output_on_terminal(
 fn find_paths(starting_point: &str, query: &str, limit: u16) -> Result<Vec<MatchedPath>> {
     let mut paths = Vec::with_capacity(100); // TODO: Tune this capacity later.
 
-    // TODO: Sort
-    for path in Finder::new(starting_point, query)?.take(limit.into()) {
+    for path in Finder::new(starting_point, query)? {
+        // TODO: Shouldn't we stop iteration when some paths retuns Err?
         let path = path?;
         paths.push(path);
     }
-    Ok(paths)
+
+    paths.sort();
+    Ok(paths.into_iter().take(limit.into()).collect())
 }
 
 fn invoke(exec: &str, path: &str) -> Result<std::process::Output> {

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
-use std::fmt::{self, Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
+use crate::matched_path::MatchedPath;
 
 pub struct Finder {
     starting_point: String,
@@ -76,7 +76,7 @@ impl ConsumedDir {
                     return Err(Error::invalid_unicode(&format!(
                         "The path {:?} does not seem to be valid unicode.",
                         path
-                    )))
+                    )));
                 }
             };
             // TODO: Symbolic link?
@@ -102,48 +102,6 @@ impl Iterator for ConsumedDir {
     }
 }
 
-#[derive(Debug)]
-pub struct MatchedPath {
-    pub absolute: String,
-    pub relative: String,
-    pub positions: Vec<usize>,
-}
-
-impl Display for MatchedPath {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.relative, f)
-    }
-}
-
-impl MatchedPath {
-    pub(super) fn new(query: &str, starting_point: &str, absolute: &str) -> Option<Self> {
-        let relative: Vec<char> = absolute
-            .strip_prefix(starting_point)
-            .expect("The passed starting_point must be prefix of the path.")
-            .chars()
-            .collect();
-        let relative = &relative[1..]; // NOTE: Delete the prefix of slash
-        let mut positions: Vec<usize> = vec![];
-        for char in normalize_query(query).chars() {
-            let begin = if let Some(pos) = positions.last() {
-                pos + 1
-            } else {
-                0
-            };
-            // TODO: Explain this line later.
-            let target = &relative[begin..];
-            let pos = target.iter().position(|t| char.eq_ignore_ascii_case(t))?;
-            positions.push(begin + pos);
-        }
-        Some(Self {
-            absolute: absolute.to_string(),
-            relative: relative.iter().collect(),
-            positions,
-        })
-    }
-    // TODO: Present with colorized value with emphasized positions.
-}
-
 fn canonicalize_starting_point(path: &Path) -> Result<PathBuf> {
     path.canonicalize().map_err(|_e|
         Error::args(&format!(
@@ -151,16 +109,4 @@ fn canonicalize_starting_point(path: &Path) -> Result<PathBuf> {
             path,
         ))
     )
-}
-
-#[cfg(target_os = "windows")]
-fn normalize_query(query: &str) -> String {
-    // NOTE: Forward slashes are not allowed in a filename, so this replacing is supposed to work.
-    //       See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-    query.replace('/', "\\")
-}
-
-#[cfg(not(target_os = "windows"))]
-fn normalize_query(query: &str) -> &str {
-    query
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub use cli::entrypoint;
 pub use cli::safe_exit;
 pub use error::{Error, ErrorKind, Result};
-pub use finder::{Finder, MatchedPath};
+pub use finder::Finder;
+pub use matched_path::MatchedPath;
 
 mod args;
 mod cli;
 mod error;
 mod finder;
+mod matched_path;

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -1,0 +1,169 @@
+use std::cmp::Ordering;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct MatchedPath {
+    pub absolute: String,
+    pub relative: String,
+    pub positions: Vec<usize>,
+    pub depth: usize,
+}
+
+impl Display for MatchedPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.relative, f)
+    }
+}
+
+impl MatchedPath {
+    pub(crate) fn new(query: &str, starting_point: &str, absolute: &str) -> Option<Self> {
+        let mut depth = 0;
+        let relative: Vec<char> = absolute
+            .strip_prefix(starting_point)
+            .expect("The passed starting_point must be prefix of the path.")
+            .chars()
+            .collect();
+        let relative = &relative[1..]; // NOTE: Delete the prefix of slash
+        let mut positions: Vec<usize> = vec![];
+        for char in normalize_query(query).chars() {
+            if char == '/' {
+                depth += 1;
+            }
+            let begin = if let Some(pos) = positions.last() {
+                pos + 1
+            } else {
+                0
+            };
+            // TODO: Explain this line later.
+            let target = &relative[begin..];
+            let pos = target.iter().position(|t| char.eq_ignore_ascii_case(t))?;
+            positions.push(begin + pos);
+        }
+        Some(Self {
+            absolute: absolute.to_string(),
+            relative: relative.iter().collect(),
+            positions,
+            depth,
+        })
+    }
+
+    /// Calculate the total distance between each position.
+    /// For example, if the `positions` is `vec![1, 2, 3]`, then the distance will be `2`.
+    /// If the `positions` is `vec![1, 4, 5]`, then the distance will be `4`.
+    /// The least distance is `length of query - 1`.
+    fn distance(&self) -> usize {
+        let mut iter = self.positions.iter().peekable();
+        let mut total = 0;
+        while let Some(pos) = iter.next() {
+            if let Some(next) = iter.peek() {
+                total += *next - pos;
+            }
+        }
+        total
+    }
+    // TODO: Present with colorized value with emphasized positions.
+}
+
+impl Ord for MatchedPath {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let depth = match self.distance().cmp(&other.distance()) {
+            Ordering::Equal => self.depth.cmp(&other.depth),
+            any => any,
+        };
+        match depth {
+            Ordering::Equal => self.relative.cmp(&other.relative),
+            any => any,
+        }
+    }
+}
+
+impl PartialOrd for MatchedPath {
+    fn partial_cmp(&self, other: &MatchedPath) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn normalize_query(query: &str) -> String {
+    // NOTE: Forward slashes are not allowed in a filename, so this replacing is supposed to work.
+    //       See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    query.replace('/', "\\")
+}
+
+#[cfg(not(target_os = "windows"))]
+fn normalize_query(query: &str) -> &str {
+    query
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distance() {
+        assert_eq!(
+            MatchedPath::new("abc", "/home", "/home/abc.txt")
+                .unwrap()
+                .distance(),
+            2
+        );
+        assert_eq!(
+            MatchedPath::new("abc", "/home", "/home/a123bc.txt")
+                .unwrap()
+                .distance(),
+            5
+        );
+        assert_eq!(
+            MatchedPath::new("foo.txt", "/home", "/home/ok/foo.txt")
+                .unwrap()
+                .distance(),
+            6
+        );
+        assert_eq!(
+            MatchedPath::new("foo.txt", "/home", "/home/ok/f1o1o/ok.txt")
+                .unwrap()
+                .distance(),
+            11
+        );
+        assert_eq!(
+            MatchedPath::new("foo.txt", "/home", "/home/ok/foo/ok.txt")
+                .unwrap()
+                .distance(),
+            9
+        );
+    }
+
+    #[test]
+    fn sort() {
+        let mut given = vec![
+            MatchedPath::new("abc.txt", "/home", "/home/abc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/a12bc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/a123bc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/abc/cat.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/abc/src/abc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/src/abc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/aXbc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/Foo-aXbc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/Foo-aXbXc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/abc.txt").unwrap(),
+            MatchedPath::new("abc.txt", "/home", "/home/lib/abc!.txt").unwrap(),
+        ];
+        given.sort();
+        assert_eq!(
+            given,
+            vec![
+                MatchedPath::new("abc.txt", "/home", "/home/abc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/src/abc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/abc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/lib/abc!.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/Foo-aXbc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/aXbc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/a12bc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/src/n1/n2/Foo-aXbXc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/a123bc.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/abc/cat.txt").unwrap(),
+                MatchedPath::new("abc.txt", "/home", "/home/abc/src/abc.txt").unwrap(), // TODO: This should precede others. positions should be updated within ::new
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Close #30 

We can sort slices with this struct with the implementation of `Ord` for
`MatchedPath`. This will be useful to show plausible file path
candidates.