### PR TITLE
Replace `Command` with `libc::execvp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "lock_api"
@@ -258,6 +258,7 @@ name = "thwack"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "libc",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 
 [dependencies]
 crossterm = { version = "0.19.0", default-features = false }
+libc = "0.2.95"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,7 +15,7 @@ ARGS:
 OPTIONS:
     --exec <COMMAND>          Change the execution command from the default.
                               This is run when you hit the Enter on a path
-                              The default command is \"type\" on Windows, or \"cat\" on other platforms.
+                              The default command is \"notepad\" on Windows, or \"cat\" on other platforms.
     --starting-point <PATH>   Change the starting point from the default (\".\")
     -h, --help                Prints help information";
 
@@ -140,7 +140,7 @@ impl Default for ParsedArgs {
             starting_point: String::from("."),
             query: String::from(""),
             exec: if cfg!(windows) {
-                String::from("type")
+                String::from("notepad")
             } else {
                 String::from("cat")
             },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -184,7 +184,7 @@ fn find_paths(starting_point: &str, query: &str, limit: u16) -> Result<Vec<Match
     Ok(paths.into_iter().take(limit.into()).collect())
 }
 
-/// Invoke the specific command and replace this
+/// Invoke the specified command with the selected path.
 fn invoke(exec: &str, path: &str) -> Result<()> {
     let mut cstrings: Vec<CString> = Vec::with_capacity(10); // TODO: Why is it 10?
     for arg in exec.split_whitespace() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,7 @@ fn output_on_terminal(
     for (idx, path) in paths.iter().enumerate() {
         let idx = idx as u16;
         let prefix = if idx == selection { "> " } else { "  " };
-        queue!(stdout, style::Print(format!("{}", prefix)))?;
+        queue!(stdout, style::Print(prefix))?;
         for chunk in path.chunks() {
             if chunk.matched() {
                 queue!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,9 @@
 use std::env::ArgsOs;
+use std::ffi::CString;
 use std::io::{self, Stderr, Stdout, Write};
+use std::os::raw::c_char;
 use std::process::exit;
+use std::ptr;
 use std::time::Duration;
 
 use crossterm::{
@@ -23,7 +26,7 @@ pub fn safe_exit(code: i32, stdout: Stdout, stderr: Stderr) {
     exit(code)
 }
 
-pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write, stderr: &mut impl Write) -> Result<()> {
+pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write) -> Result<()> {
     let args = Parser::new(args).parse()?;
     if args.help {
         print_help(stdout)?;
@@ -105,15 +108,7 @@ pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write, stderr: &mut impl Write
     if let State::Invoke(path) = state {
         // TODO: Decide which we should pass: relative or absolute.
         let path = path.relative();
-        let output = invoke(&args.exec, path)?;
-        stdout.write_all(&output.stdout)?;
-        stderr.write_all(&output.stderr)?;
-        if !output.status.success() {
-            return Err(Error::exec(&format!(
-                "Failed to execute command `{} {}`",
-                args.exec, path,
-            )));
-        }
+        invoke(&args.exec, path)?;
     }
     Ok(())
 }
@@ -189,16 +184,23 @@ fn find_paths(starting_point: &str, query: &str, limit: u16) -> Result<Vec<Match
     Ok(paths.into_iter().take(limit.into()).collect())
 }
 
-fn invoke(exec: &str, path: &str) -> Result<std::process::Output> {
-    let mut exec = exec.split_whitespace();
-    let program = exec
-        .next()
-        .ok_or_else(|| Error::args("\"exec\" cannot be processed with empty string"))?;
-    let mut command = std::process::Command::new(program);
-    for arg in exec {
-        command.arg(arg);
+/// Invoke the specific command and replace this
+fn invoke(exec: &str, path: &str) -> Result<()> {
+    let mut cstrings: Vec<CString> = Vec::with_capacity(10); // TODO: Why is it 10?
+    for arg in exec.split_whitespace() {
+        cstrings.push(CString::new(arg)?);
     }
-    command.arg(path);
-    let output = command.output()?;
-    Ok(output)
+    cstrings.push(CString::new(path)?);
+    let argv: Vec<*const c_char> = cstrings
+        .iter()
+        .map(|c| c.as_ptr())
+        .chain(std::iter::once(ptr::null()))
+        .collect();
+
+    let errno = unsafe { libc::execvp(cstrings[0].as_ptr(), argv.as_ptr()) };
+
+    Err(Error::exec(&format!(
+        "`{} {}` failed and returned {}",
+        exec, path, errno
+    )))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use std::error;
+use std::ffi::NulError;
 use std::fmt::{self, Display, Formatter};
 use std::io;
 use std::result::Result as StdResult;
@@ -15,6 +16,7 @@ pub enum ErrorKind {
     IO,
     Terminal,
     Exec,
+    NulError,
 }
 
 #[derive(Debug)]
@@ -98,6 +100,20 @@ impl From<crossterm::ErrorKind> for Error {
                 error
             ),
             kind: ErrorKind::Terminal,
+            source: Some(Box::new(error)),
+            exit_code: FAILURE,
+        }
+    }
+}
+
+impl From<NulError> for Error {
+    fn from(error: NulError) -> Self {
+        Self {
+            message: format!(
+                "The string contains nul bytes. See the details from .source: {}",
+                error
+            ),
+            kind: ErrorKind::NulError,
             source: Some(Box::new(error)),
             exit_code: FAILURE,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use thwack::{entrypoint, safe_exit};
 fn main() {
     let mut out = stdout();
     let mut err = stderr();
-    match entrypoint(env::args_os(), &mut out, &mut err) {
+    match entrypoint(env::args_os(), &mut out) {
         Ok(_) => safe_exit(0, out, err),
         Err(e) => {
             eprintln!("{}", e); // TODO: Write a more readable error message.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use thwack::{entrypoint, safe_exit};
 
 fn main() {
     let mut out = stdout();
-    let mut err = stderr();
+    let err = stderr();
     match entrypoint(env::args_os(), &mut out) {
         Ok(_) => safe_exit(0, out, err),
         Err(e) => {


### PR DESCRIPTION
Using `libc::execvp`, thwack doesn't have to care about the output by
`Command`. Plus, it can replace itself with the new process image on
UNIX-like systems. On Windows, the behavior itself might be the same as
before.