### PR TITLE
Use grapheme cluster to detect correct indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,14 @@ dependencies = [
  "crossterm",
  "libc",
  "tempfile",
+ "unicode-segmentation",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 [dependencies]
 crossterm = { version = "0.19.0", default-features = false }
 libc = "0.2.95"
+unicode-segmentation = "1.7.1"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,7 +187,7 @@ fn output_on_terminal(
     Ok(())
 }
 
-fn find_paths(starting_point: &str, query: &str, limit: u16) -> Result<Vec<MatchedPath>> {
+fn find_paths<'a>(starting_point: &'a str, query: &'a str, limit: u16) -> Result<Vec<MatchedPath>> {
     let mut paths = Vec::with_capacity(100); // TODO: Tune this capacity later.
 
     for path in Finder::new(starting_point, query)? {

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -4,27 +4,27 @@ use std::path::{Path, PathBuf};
 use crate::error::{Error, Result};
 use crate::matched_path::MatchedPath;
 
-pub(crate) struct Finder {
+pub(crate) struct Finder<'a> {
     starting_point: String,
-    query: String,
+    query: &'a str,
     dirs: VecDeque<ConsumedDir>,
 }
 
-impl Finder {
-    pub(crate) fn new(starting_point: &str, query: &str) -> Result<Self> {
+impl<'a> Finder<'a> {
+    pub(crate) fn new(starting_point: &str, query: &'a str) -> Result<Self> {
         let mut dirs = VecDeque::with_capacity(100);
         let consumed_dir = ConsumedDir::new(starting_point)?;
         let starting_point = consumed_dir.root.clone();
         dirs.push_back(consumed_dir);
         Ok(Self {
             starting_point,
-            query: query.to_string(),
+            query,
             dirs,
         })
     }
 }
 
-impl Iterator for Finder {
+impl<'a> Iterator for Finder<'a> {
     type Item = Result<MatchedPath>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -46,7 +46,7 @@ impl Iterator for Finder {
                     continue;
                 }
             };
-            match MatchedPath::new(&self.query, &self.starting_point, &absolute) {
+            match MatchedPath::new(self.query, &self.starting_point, &absolute) {
                 Some(matched) => return Some(Ok(matched)),
                 None => continue,
             }


### PR DESCRIPTION
According to the rust API, `str::chars` does not seem to support
grapheme clusters.

https://doc.rust-lang.org/std/primitive.str.html#method.chars

This patch introduces `unicode-segmentation` to support such characters.