### PR TITLE
Add a new struct: StartingPoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/tmp/**/*
+!/tmp/.keep

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,7 @@ use crate::args::{Parser, HELP};
 use crate::error::Result;
 use crate::finder::Finder;
 use crate::matched_path::MatchedPath;
+use crate::starting_point::StartingPoint;
 use crate::Error;
 
 pub fn safe_exit(code: i32, stdout: Stdout, stderr: Stderr) {
@@ -50,8 +51,9 @@ pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write) -> Result<()> {
     }
 
     let (_, mut rows) = terminal::size()?;
+    let starting_point = StartingPoint::new(args.starting_point)?;
     let mut query = args.query;
-    let mut paths = find_paths(&args.starting_point, &query, rows - 1)?;
+    let mut paths = find_paths(&starting_point, &query, rows - 1)?;
     let mut selection: u16 = 0;
     let mut state = State::QueryChanged;
     initialize_terminal(stdout)?;
@@ -112,7 +114,7 @@ pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write) -> Result<()> {
                 state = State::PathsChanged;
             }
         } else if let State::QueryChanged = state {
-            paths = find_paths(&args.starting_point, &query, rows - 1)?;
+            paths = find_paths(&starting_point, &query, rows - 1)?;
             state = State::PathsChanged;
             selection = 0;
         }
@@ -187,7 +189,7 @@ fn output_on_terminal(
     Ok(())
 }
 
-fn find_paths<'a>(starting_point: &'a str, query: &'a str, limit: u16) -> Result<Vec<MatchedPath>> {
+fn find_paths(starting_point: &StartingPoint, query: &str, limit: u16) -> Result<Vec<MatchedPath>> {
     let mut paths = Vec::with_capacity(100); // TODO: Tune this capacity later.
 
     for path in Finder::new(starting_point, query)? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ mod cli;
 mod error;
 mod finder;
 mod matched_path;
+mod starting_point;

--- a/src/starting_point.rs
+++ b/src/starting_point.rs
@@ -1,0 +1,66 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct StartingPoint(String);
+
+impl StartingPoint {
+    pub(crate) fn new(dir: impl AsRef<Path>) -> Result<Self> {
+        let dir = canonicalize_starting_point(dir.as_ref())?;
+        let root = path_to_string(&dir)?;
+        Ok(Self(root))
+    }
+}
+
+impl AsRef<str> for StartingPoint {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+fn canonicalize_starting_point(path: &Path) -> Result<PathBuf> {
+    path.canonicalize().map_err(|_e|
+        Error::args(&format!(
+            "The specified starting point {:?} cannot be normalized. Perhaps, it might not exist or cannot be read.",
+            path,
+        ))
+    )
+}
+
+fn path_to_string(path: &Path) -> Result<String> {
+    path.to_str().map(|s| s.to_string()).ok_or_else(|| {
+        Error::invalid_unicode(&format!(
+            "The path {:?} does not seem to be valid unicode.",
+            path
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `tmp` is located in the root directory of this repository.
+    fn tmp() -> String {
+        let path: &Path = "tmp".as_ref();
+        path.canonicalize().unwrap().to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn new() {
+        assert_eq!(StartingPoint::new("tmp").unwrap(), StartingPoint(tmp()));
+    }
+
+    #[test]
+    fn new_fail_with_non_existent_dir() {
+        let result = StartingPoint::new("non_existent_dir");
+        assert!(result.is_err());
+        assert_eq!(format!("{}", result.unwrap_err()), "The specified starting point \"non_existent_dir\" cannot be normalized. Perhaps, it might not exist or cannot be read.");
+    }
+
+    #[test]
+    fn as_ref() {
+        assert_eq!(StartingPoint::new("tmp").unwrap().as_ref(), &tmp());
+    }
+}


### PR DESCRIPTION
This struct is intended for a caller of `Finder` to specify the correct
`starting_point` in advance. **The correct `starting_point`** means the
path which is valid in terms of character encdoing, and really exists in
a file system; in other words, it can be `canonicalize`d safely.

With this refactoring, each `ConsumedDir` does not have to call
`canonicalize` because `Finder` can get absolute path due to the
`canonicalize`d `starting_point`.