### PR TITLE
Returns Chunks based on the terminal size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "libc",
  "tempfile",
  "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -268,6 +269,12 @@ name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 crossterm = { version = "0.19.0", default-features = false }
 libc = "0.2.95"
 unicode-segmentation = "1.7.1"
+unicode-width = "0.1.8"
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
Close #57 

Sometimes, a user may come across the case that some of the file
candidates are too long for the terminal to wrap them and cause the
broken screen. This patch tries to alleviate such a situation to omit
them with an ellipsis. Some of the matched characters will be lost
because of the omission, but I want to prioritize to maintain the screen
not broken.