### PR TITLE
Revert "Bump github-changelog-generator from v1.16.2 to v1.16.4"

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,7 +28,7 @@ jobs:
           fi
           echo "::set-output name=args::#{args}"
       - uses: actions/checkout@v2
-      - uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.4
+      - uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
         with:
           args: '--user ${{ github.repository_owner }} --project ${{ steps.get_project.outputs.project }} --exclude-labels chore,no-changelog,duplicate,question,invalid,wontfix ${{ steps.get_future_release.outputs.args }}'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           echo "::set-output name=commit_short::$(git rev-parse --short HEAD)"
           echo "::set-output name=date::$(date --utc +%Y-%m-%d)"
-
       - name: Create a GitHub release and publish the crate on crates.io
         run: |
           set -xeuo pipefail


### PR DESCRIPTION
Reverts yykamei/thwack#75 because of this error https://github.com/yykamei/thwack/actions/runs/921599583

1.16.4 hasn't been published so far.