### PR TITLE
Set CARGO_REGISTRY_TOKEN for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,3 +70,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHORT: ${{ steps.set_metadata.outputs.commit_short  }}
           DATE: ${{ steps.set_metadata.outputs.date  }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Use the environment variable `CARGO_REGISTRY_TOKEN`  to publish a new package.

See https://doc.rust-lang.org/cargo/reference/config.html#registrytoken for more details about this parameter.