### PR TITLE
Bump crossterm from 0.19.0 to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,25 +14,25 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossterm"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c"
+checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "lazy_static",
  "libc",
  "mio",
  "parking_lot",
  "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
 dependencies = [
  "winapi",
 ]
@@ -56,12 +56,6 @@ checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -215,20 +209,30 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
- "mio",
  "signal-hook-registry",
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.3.0"
+name = "signal-hook-mio"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 version = "0.2.0"
 
 [dependencies]
-crossterm = { version = "0.19.0", default-features = false }
+crossterm = "0.20.0"
 libc = "0.2.97"
 unicode-segmentation = "1.7.1"
 unicode-width = "0.1.8"

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,20 +92,6 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<crossterm::ErrorKind> for Error {
-    fn from(error: crossterm::ErrorKind) -> Self {
-        Self {
-            message: format!(
-                "Unhandled terminal error happened. See the details from .source: {}",
-                error
-            ),
-            kind: ErrorKind::Terminal,
-            source: Some(Box::new(error)),
-            exit_code: FAILURE,
-        }
-    }
-}
-
 impl From<NulError> for Error {
     fn from(error: NulError) -> Self {
         Self {


### PR DESCRIPTION
Close #97 

Summary:

Bump crossterm from 0.19.0 to 0.20.0. This requires extra work to remove
`impl From<crossterm::ErrorKind> for Error` because `crossterm::ErrorKind`
became just an alias of `io::Error`. We don't have to convert crossterm
specific errors. See https://github.com/crossterm-rs/crossterm/pull/553
for more details.

Release note:

https://github.com/crossterm-rs/crossterm/releases

Changelog:

https://github.com/crossterm-rs/crossterm/blob/master/CHANGELOG.md