### PR TITLE
Pass absolute path to the specified command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,9 +117,7 @@ pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write) -> Result<()> {
     terminal::disable_raw_mode()?;
 
     if let State::Invoke(path) = state {
-        // TODO: Decide which we should pass: relative or absolute.
-        let path = path.relative();
-        invoke(&args.exec, path)?;
+        invoke(&args.exec, path.absolute())?;
     }
     Ok(())
 }
@@ -189,7 +187,7 @@ fn find_paths(starting_point: &StartingPoint, query: &str, limit: u16) -> Result
     let mut paths = Vec::with_capacity(100); // TODO: Tune this capacity later.
 
     for path in Finder::new(starting_point, query)? {
-        // TODO: Shouldn't we stop iteration when some paths retuns Err?
+        // TODO: Shouldn't we stop iteration when some paths returns Err?
         let path = path?;
         paths.push(path);
     }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -153,7 +153,7 @@ mod tests {
         }
         let mut paths: Vec<String> = paths
             .iter()
-            .map(|m| m.relative().replace('\\', "/"))
+            .map(|m| format!("{}", m).replace('\\', "/"))
             .collect();
         paths.sort();
         paths

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -8,9 +8,20 @@ use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct MatchedPath {
+    /// *absolute* is an absolute path/
     absolute: String,
+
+    /// *relative* is a path to `starting_point` passed as an argument of `new`.
+    ///
+    /// CAUTION: You should not pass it as a target file for command
+    ///          because `starting_point` sometimes differs from the current working directory,
+    ///          in which this program is run.
     relative: String,
+
+    /// *depth* is the number of path separator.
     depth: usize,
+
+    /// *positions* is a vector containing the matched indicies of *relative*.
     positions: Vec<usize>,
 }
 
@@ -35,9 +46,9 @@ impl MatchedPath {
         })
     }
 
-    /// Returns the relative path
-    pub(crate) fn relative(&self) -> &str {
-        &self.relative
+    /// Returns the absolute path.
+    pub(crate) fn absolute(&self) -> &str {
+        &self.absolute
     }
 
     /// Returns the slice of Chunks. This generates reduced chunks if `Self::width` exceeds the `max_width`.
@@ -293,9 +304,9 @@ mod tests {
     }
 
     #[test]
-    fn returns_relative() {
+    fn returns_absolute() {
         let path = new("abc", "/home", "/home/abc.txt");
-        assert_eq!(path.relative(), "abc.txt");
+        assert_eq!(path.absolute(), "/home/abc.txt");
     }
 
     #[test]


### PR DESCRIPTION
`MatchedPath::relative` cannot be accessed because `starting_point`
sometimes differs because of the `--starting-point` option. With
`--starting-point`, we should not use the *relative* path.

In the first place, I believe there are few commands to require relative
paths for their argument. Thus, I made `invoke` receive an absolute
path.