### PR TITLE
Fix Resize event handling to update paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,7 @@ pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write) -> Result<()> {
             } else if let Event::Resize(c, r) = ev {
                 columns = c;
                 rows = r;
+                paths = find_paths(&starting_point, &query, paths_rows(rows))?;
                 state = State::PathsChanged;
             }
         } else if let State::QueryChanged = state {


### PR DESCRIPTION
When the Resize event occurs, `paths` must be updated to fix them to the
window size.