### PR TITLE
Refactor MatchedPath to return chunks of absolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,4 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_RUST_CLIPPY: false
+          LOG_LEVEL: TRACE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,3 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_RUST_CLIPPY: false
-          LOG_LEVEL: TRACE

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,7 +189,7 @@ fn output_on_terminal(
         queue!(stdout, style::Print(prefix))?;
 
         let max_columns: usize = max_columns as usize - 2; // The prefix "> " requires 2 columns.
-        for chunk in path.chunks(max_columns) {
+        for chunk in path.relative_chunks(max_columns) {
             if chunk.matched() {
                 queue!(
                     stdout,

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -338,14 +338,14 @@ mod tests {
     #[test]
     fn returns_absolute_chunks() {
         assert_eq!(
-            new("abc.txt", "/", "/abc/abc/abc.txt").absolute_chunks(30),
+            new("foo.txt", "/", "/foo/abc/foo.txt").absolute_chunks(30),
             vec![
                 Chunk {
-                    value: String::from("/abc/abc/"),
+                    value: String::from("/foo/abc/"),
                     matched: false,
                 },
                 Chunk {
-                    value: String::from("abc.txt"),
+                    value: String::from("foo.txt"),
                     matched: true,
                 },
             ],
@@ -370,8 +370,8 @@ mod tests {
         assert_eq!(
             new(
                 "tem",
-                "C:\\Documents",
-                "C:\\Documents\\Newsletters\\Summer2018.pdf"
+                "C:\\Downloads",
+                "C:\\Downloads\\Newsletters\\Summer2018.pdf"
             )
             .absolute_chunks(28),
             vec![
@@ -398,10 +398,10 @@ mod tests {
             ],
         );
         assert_eq!(
-            new("foo☕t", "\\Folder\\", "\\Folder\\foo\\bar\\☕.txt").absolute_chunks(30),
+            new("foo🍦t", "\\FF\\", "\\FF\\foo\\bar\\🍦.txt").absolute_chunks(50),
             vec![
                 Chunk {
-                    value: String::from("\\Folder\\"),
+                    value: String::from("\\FF\\"),
                     matched: false,
                 },
                 Chunk {
@@ -413,7 +413,7 @@ mod tests {
                     matched: false,
                 },
                 Chunk {
-                    value: String::from("☕"),
+                    value: String::from("🍦"),
                     matched: true,
                 },
                 Chunk {
@@ -427,10 +427,10 @@ mod tests {
             ],
         );
         assert_eq!(
-            new("a̐éö̲", "/", "/abc/Aa̐Béö̲.txt").absolute_chunks(30),
+            new("a̐éö̲", "/", "/☕/Aa̐Béö̲.txt").absolute_chunks(30),
             vec![
                 Chunk {
-                    value: String::from("/abc/A"),
+                    value: String::from("/☕/A"),
                     matched: false,
                 },
                 Chunk {
@@ -452,7 +452,7 @@ mod tests {
             ],
         );
         assert_eq!(
-            new("☕.txt", "/", "/abc/☕/abc/☕.txt").absolute_chunks(15),
+            new("☕.txt", "/", "/☕/☕/abc/☕.txt").absolute_chunks(15),
             vec![
                 Chunk {
                     value: String::from(".../abc/"),
@@ -465,21 +465,29 @@ mod tests {
             ],
         );
         assert_eq!(
-            new("👩‍🔬☕", "C:\\", "C:\\Documents\\👩‍🔬\\🦑\\abcde\\☕🌍.txt").absolute_chunks(24),
+            new("👩‍🔬🗑", "C:\\", "C:\\Documents\\👩‍🔬\\🦑\\abcde\\🗑🌍.txt").absolute_chunks(24),
             vec![
                 Chunk {
-                    value: String::from("...\\🦑\\abcde\\"),
-                    matched: false,
+                    value: String::from("..."),
+                    matched: false
                 },
                 Chunk {
-                    value: String::from("☕"),
-                    matched: true,
+                    value: String::from("👩‍🔬"),
+                    matched: true
+                },
+                Chunk {
+                    value: String::from("\\🦑\\abcde\\"),
+                    matched: false
+                },
+                Chunk {
+                    value: String::from("🗑"),
+                    matched: true
                 },
                 Chunk {
                     value: String::from("🌍.txt"),
-                    matched: false,
-                },
-            ],
+                    matched: false
+                }
+            ]
         );
     }
 

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -351,116 +351,45 @@ mod tests {
             ],
         );
         assert_eq!(
-            new("abc", "/", "/abc/abc/abc.txt").absolute_chunks(30),
+            new("abc.txt", "/", "/morning/morning/abc.txt").absolute_chunks(30),
             vec![
                 Chunk {
-                    value: String::from("/abc/abc/"),
+                    value: String::from("/morning/morning/"),
                     matched: false,
                 },
                 Chunk {
-                    value: String::from("abc"),
+                    value: String::from("abc.txt"),
                     matched: true,
-                },
-                Chunk {
-                    value: String::from(".txt"),
-                    matched: false,
                 },
             ],
         );
         assert_eq!(
             new(
-                "tem",
+                "gs",
                 "C:\\Downloads",
-                "C:\\Downloads\\Newsletters\\Summer2018.pdf"
+                "C:\\Downloads\\Final\\Porting\\Special2019.pdf"
             )
             .absolute_chunks(28),
             vec![
                 Chunk {
-                    value: String::from("...ewslet"),
+                    value: String::from("...l\\Portin"),
                     matched: false,
                 },
                 Chunk {
-                    value: String::from("te"),
+                    value: String::from("g"),
                     matched: true,
                 },
                 Chunk {
-                    value: String::from("rs\\Sum"),
+                    value: String::from("\\"),
                     matched: false,
                 },
                 Chunk {
-                    value: String::from("m"),
+                    value: String::from("S"),
                     matched: true,
                 },
                 Chunk {
-                    value: String::from("er2018.pdf"),
+                    value: String::from("pecial2019.pdf"),
                     matched: false,
-                },
-            ],
-        );
-        assert_eq!(
-            new("foo🍦t", "\\FF\\", "\\FF\\foo\\bar\\🍦.txt").absolute_chunks(50),
-            vec![
-                Chunk {
-                    value: String::from("\\FF\\"),
-                    matched: false,
-                },
-                Chunk {
-                    value: String::from("foo"),
-                    matched: true,
-                },
-                Chunk {
-                    value: String::from("\\bar\\"),
-                    matched: false,
-                },
-                Chunk {
-                    value: String::from("🍦"),
-                    matched: true,
-                },
-                Chunk {
-                    value: String::from(".tx"),
-                    matched: false,
-                },
-                Chunk {
-                    value: String::from("t"),
-                    matched: true,
-                },
-            ],
-        );
-        assert_eq!(
-            new("a̐éö̲", "/", "/☕/Aa̐Béö̲.txt").absolute_chunks(30),
-            vec![
-                Chunk {
-                    value: String::from("/☕/A"),
-                    matched: false,
-                },
-                Chunk {
-                    value: String::from("a̐"),
-                    matched: true,
-                },
-                Chunk {
-                    value: String::from("B"),
-                    matched: false,
-                },
-                Chunk {
-                    value: String::from("éö̲"),
-                    matched: true,
-                },
-                Chunk {
-                    value: String::from(".txt"),
-                    matched: false,
-                },
-            ],
-        );
-        assert_eq!(
-            new("☕.txt", "/", "/☕/☕/abc/☕.txt").absolute_chunks(15),
-            vec![
-                Chunk {
-                    value: String::from(".../abc/"),
-                    matched: false,
-                },
-                Chunk {
-                    value: String::from("☕.txt"),
-                    matched: true,
                 },
             ],
         );


### PR DESCRIPTION
`MatchedPath` can return chunks of `absolute`, so I refactored the
implementation.

In addition, I added `truncated_absolute` to allow us to get an absolute
path truncated within the window.