### PR TITLE
Change selection when the resize event happens

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,11 @@ pub fn entrypoint(args: ArgsOs, stdout: &mut impl Write) -> Result<()> {
             } else if let Event::Resize(c, r) = ev {
                 columns = c;
                 rows = r;
+                selection = if selection > r {
+                    paths_rows(r) - 1
+                } else {
+                    selection
+                };
                 paths = find_paths(&starting_point, &query, paths_rows(rows))?;
                 state = State::PathsChanged;
             }


### PR DESCRIPTION
If the `selection` remains when the resize event happens, selected
cursor sometimes disappears. This patch tries to keep the selection
within the window.