### PR TITLE
[refactor] Add show_version.rs to test --version

### DIFF
--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -35,18 +35,26 @@ impl Write for Buffer {
         Ok(self.inner.len())
     }
 
-    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        let _ = self.inner.extend(buf);
+    fn flush(&mut self) -> Result<()> {
         Ok(())
     }
 
-    fn flush(&mut self) -> Result<()> {
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        let _ = self.inner.extend(buf);
         Ok(())
     }
 }
 
 impl From<&str> for Buffer {
     fn from(s: &str) -> Self {
+        Self {
+            inner: Vec::from(s.as_bytes()),
+        }
+    }
+}
+
+impl From<String> for Buffer {
+    fn from(s: String) -> Self {
         Self {
             inner: Vec::from(s.as_bytes()),
         }

--- a/tests/show_version.rs
+++ b/tests/show_version.rs
@@ -1,0 +1,36 @@
+use std::ffi::OsString;
+
+use thwack::entrypoint;
+
+mod helper;
+
+fn version() -> String {
+    format!("{} {}\n", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+}
+
+#[test]
+fn show_version() {
+    let args = args!["thwack", "--version"];
+    let mut buffer = buf!();
+    let result = entrypoint(args, &mut buffer);
+    assert!(result.is_ok());
+    assert_eq!(buffer, buf!(version()));
+}
+
+#[test]
+fn show_version_with_query() {
+    let args = args!["thwack", "--version", "--", "query"];
+    let mut buffer = buf!();
+    let result = entrypoint(args, &mut buffer);
+    assert!(result.is_ok());
+    assert_eq!(buffer, buf!(version()));
+}
+
+#[test]
+fn show_version_with_starting_point() {
+    let args = args!["thwack", "--version", "--starting-point=/tmp"];
+    let mut buffer = buf!();
+    let result = entrypoint(args, &mut buffer);
+    assert!(result.is_ok());
+    assert_eq!(buffer, buf!(version()));
+}


### PR DESCRIPTION
This is a part of #131.

I want to test the functionality of `--version` to confirm the version is output with this option.