### PR TITLE
[refafctor] Add Terminal trait for testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub use args::HELP;
 pub use cli::{entrypoint, safe_exit};
 pub use error::{Error, ErrorKind, Result};
+pub use terminal::{DefaultTerminal, Terminal};
 
 mod args;
 mod cli;
@@ -8,3 +9,4 @@ mod error;
 mod finder;
 mod matched_path;
 mod starting_point;
+mod terminal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use std::env;
 use std::io::{stderr, stdout};
 
-use thwack::{entrypoint, safe_exit};
+use thwack::{entrypoint, safe_exit, DefaultTerminal};
 
 fn main() {
     let mut out = stdout();
     let err = stderr();
-    match entrypoint(env::args_os(), &mut out) {
+    match entrypoint(env::args_os(), &mut out, DefaultTerminal) {
         Ok(_) => safe_exit(0, out, err),
         Err(e) => {
             eprintln!("{}", e); // TODO: Write a more readable error message.

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -198,8 +198,8 @@ fn chunks_from(path: &str, positions: &[usize], max_width: usize) -> Vec<Chunk> 
             matched: false,
         })
     }
-    let mut grapheme_indices = path.grapheme_indices(true);
-    while let Some((idx, s)) = grapheme_indices.next() {
+    let grapheme_indices = path.grapheme_indices(true);
+    for (idx, s) in grapheme_indices {
         if idx < offset {
             continue;
         }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,26 @@
+use crossterm::terminal;
+
+use crate::error::Result;
+
+/// Terminal is a wrapper of crossterm::terminal.
+/// This is intended for mocking terminal-specific functions.
+pub trait Terminal {
+    fn size(&self) -> Result<(u16, u16)> {
+        let pair = terminal::size()?;
+        Ok(pair)
+    }
+
+    fn enable_raw_mode(&self) -> Result<()> {
+        let _ = terminal::enable_raw_mode()?;
+        Ok(())
+    }
+
+    fn disable_raw_mode(&self) -> Result<()> {
+        let _ = terminal::disable_raw_mode()?;
+        Ok(())
+    }
+}
+
+pub struct DefaultTerminal;
+
+impl Terminal for DefaultTerminal {}

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -1,4 +1,10 @@
-use std::io::{Result, Write};
+use std::fs::{create_dir_all, File};
+use std::io;
+use std::io::Write;
+
+use tempfile::{tempdir, TempDir};
+
+use thwack::{Result, Terminal};
 
 #[macro_export]
 macro_rules! buf {
@@ -30,16 +36,16 @@ impl Buffer {
 }
 
 impl Write for Buffer {
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let _ = self.inner.extend(buf);
         Ok(self.inner.len())
     }
 
-    fn flush(&mut self) -> Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 
-    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         let _ = self.inner.extend(buf);
         Ok(())
     }
@@ -67,4 +73,57 @@ impl<const N: usize> From<&[u8; N]> for Buffer {
             inner: Vec::from(&b[..]),
         }
     }
+}
+
+pub struct MockTerminal;
+
+impl Terminal for MockTerminal {
+    fn size(&self) -> Result<(u16, u16)> {
+        Ok((40, 40))
+    }
+
+    fn enable_raw_mode(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn disable_raw_mode(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub fn create_tree() -> io::Result<TempDir> {
+    let tmp = tempdir()?;
+    create_dir_all(tmp.path().join("src/a/b/c"))?;
+    create_dir_all(tmp.path().join("lib/a/b/c"))?;
+    create_dir_all(tmp.path().join(".config"))?;
+    let _ = File::create(tmp.path().join(".browserslistrc"))?;
+    let _ = File::create(tmp.path().join(".config/bar.toml"))?;
+    let _ = File::create(tmp.path().join(".config/ok.toml"))?;
+    let _ = File::create(tmp.path().join(".editorconfig"))?;
+    let _ = File::create(tmp.path().join(".env"))?;
+    let _ = File::create(tmp.path().join(".env.local"))?;
+    let _ = File::create(tmp.path().join(".gitignore"))?;
+    let _ = File::create(tmp.path().join(".npmrc"))?;
+    let _ = File::create(tmp.path().join(".nvmrc"))?;
+    let _ = File::create(tmp.path().join("Dockerfile"))?;
+    let _ = File::create(tmp.path().join("LICENSE"))?;
+    let _ = File::create(tmp.path().join("README.md"))?;
+    let _ = File::create(tmp.path().join("lib/a/b/c/index.js"))?;
+    let _ = File::create(tmp.path().join("lib/a/b/c/☕.js"))?;
+    let _ = File::create(tmp.path().join("lib/a/b/index.js"))?;
+    let _ = File::create(tmp.path().join("lib/a/index.js"))?;
+    let _ = File::create(tmp.path().join("lib/bar.js"))?;
+    let _ = File::create(tmp.path().join("lib/index.js"))?;
+    let _ = File::create(tmp.path().join("package-lock.json"))?;
+    let _ = File::create(tmp.path().join("package.json"))?;
+    let _ = File::create(tmp.path().join("src/a/__test__.js"))?;
+    let _ = File::create(tmp.path().join("src/a/b/c/index.js"))?;
+    let _ = File::create(tmp.path().join("src/a/b/index.js"))?;
+    let _ = File::create(tmp.path().join("src/a/index.js"))?;
+    let _ = File::create(tmp.path().join("src/a/☕.js"))?;
+    let _ = File::create(tmp.path().join("src/foo.js"))?;
+    let _ = File::create(tmp.path().join("src/index.js"))?;
+    let _ = File::create(tmp.path().join("tsconfig.json"))?;
+    let _ = File::create(tmp.path().join("☕.txt"))?;
+    Ok(tmp)
 }

--- a/tests/show_help.rs
+++ b/tests/show_help.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 
+use helper::MockTerminal;
 use thwack::{entrypoint, HELP};
 
 mod helper;
@@ -8,7 +9,7 @@ mod helper;
 fn show_help() {
     let args = args!["thwack", "--help"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }
@@ -17,7 +18,7 @@ fn show_help() {
 fn show_help_with_version() {
     let args = args!["thwack", "--help", "--version"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }
@@ -26,7 +27,7 @@ fn show_help_with_version() {
 fn show_help_with_query() {
     let args = args!["thwack", "--help", "--", "query"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }
@@ -35,7 +36,7 @@ fn show_help_with_query() {
 fn show_help_with_starting_point() {
     let args = args!["thwack", "--help", "--starting-point=/tmp"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }

--- a/tests/show_version.rs
+++ b/tests/show_version.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 
+use helper::MockTerminal;
 use thwack::entrypoint;
 
 mod helper;
@@ -12,7 +13,7 @@ fn version() -> String {
 fn show_version() {
     let args = args!["thwack", "--version"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(version()));
 }
@@ -21,7 +22,7 @@ fn show_version() {
 fn show_version_with_query() {
     let args = args!["thwack", "--version", "--", "query"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(version()));
 }
@@ -30,7 +31,7 @@ fn show_version_with_query() {
 fn show_version_with_starting_point() {
     let args = args!["thwack", "--version", "--starting-point=/tmp"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer);
+    let result = entrypoint(args, &mut buffer, MockTerminal);
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(version()));
 }


### PR DESCRIPTION
In order to stub the functions of `terminal`, I decided to wrap the
`terminal` module from `crossterm`. This new trait, `Terminal`, is
responsible for calling terminal-specific functions.