### PR TITLE
Add Buffer::normalize_path to ignore the difference between Windows and Unix

### DIFF
--- a/tests/filter_by_query.rs
+++ b/tests/filter_by_query.rs
@@ -8,7 +8,6 @@ use thwack::entrypoint;
 mod helper;
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn show_all_as_many_as_the_size_of_terminal_without_query() {
     let dir = create_tree().unwrap();
     let args = args![
@@ -23,7 +22,7 @@ fn show_all_as_many_as_the_size_of_terminal_without_query() {
     let result = entrypoint(args, &mut buffer, MockTerminal, event);
     assert!(result.is_ok());
     assert_eq!(
-        buffer,
+        buffer.normalize_path(),
         buf!(
             b"\x1b[?1049h\x1b[0m\x1b[1;1H\x1b[JSearch: \x1b7\x1b[1E\
             >\x20.browserslistrc\x1b[1E\
@@ -50,49 +49,6 @@ fn show_all_as_many_as_the_size_of_terminal_without_query() {
 }
 
 #[test]
-#[cfg(target_os = "windows")]
-fn show_all_as_many_as_the_size_of_terminal_without_query() {
-    let dir = create_tree().unwrap();
-    let args = args![
-        "thwack",
-        "--starting-point",
-        dir.path().to_str().unwrap(),
-        "--status-line=relative"
-    ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
-    let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
-    assert!(result.is_ok());
-    assert_eq!(
-        buffer,
-        buf!(
-            b"\x1b[?1049h\x1b[0m\x1b[1;1H\x1b[JSearch: \x1b7\x1b[1E\
-            >\x20.browserslistrc\x1b[1E\
-            \x20\x20.editorconfig\x1b[1E\
-            \x20\x20.env\x1b[1E\
-            \x20\x20.env.local\x1b[1E\
-            \x20\x20.gitignore\x1b[1E\
-            \x20\x20.npmrc\x1b[1E\
-            \x20\x20.nvmrc\x1b[1E\
-            \x20\x20Dockerfile\x1b[1E\
-            \x20\x20LICENSE\x1b[1E\
-            \x20\x20README.md\x1b[1E\
-            \x20\x20package-lock.json\x1b[1E\
-            \x20\x20package.json\x1b[1E\
-            \x20\x20tsconfig.json\x1b[1E\
-            \x20\x20\xe2\x98\x95.txt\x1b[1E\
-            \x20\x20.config\\bar.toml\x1b[1E\
-            \x20\x20.config\\ok.toml\x1b[1E\
-            \x20\x20lib\\bar.js\x1b[1E\
-            \x1b[19d\x1b[1m\x1b[7m.browserslistrc                                                                 \x1b[0m\x1b[1E\
-            \x1b[1m<Up>/<Ctrl-p>:\x1b[0m\x1b[1CUp\x1b[2C\x1b[1m<Down>/<Ctrl-n>:\x1b[0m\x1b[1CDown\x1b[2C\x1b[1m<Enter>:\x1b[0m\x1b[1CExecute\x1b8\x1b[?1049l"
-        )
-    );
-}
-
-#[test]
-#[cfg(not(target_os = "windows"))]
 fn show_filtered_paths_with_query() {
     let dir = create_tree().unwrap();
     let args = args![
@@ -108,7 +64,7 @@ fn show_filtered_paths_with_query() {
     let result = entrypoint(args, &mut buffer, MockTerminal, event);
     assert!(result.is_ok());
     assert_eq!(
-        buffer,
+        buffer.normalize_path(),
         buf!(
             b"\x1b[?1049h\x1b[0m\x1b[1;1H\x1b[JSearch: browser\x1b7\x1b[1E\
             >\x20.\x1b[1mbrowse\x1b[0mrslist\x1b[1mr\x1b[0mc\x1b[1E\
@@ -119,7 +75,6 @@ fn show_filtered_paths_with_query() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn show_filtered_paths_with_query_interactively() {
     let dir = create_tree().unwrap();
     let args = args![
@@ -142,7 +97,7 @@ fn show_filtered_paths_with_query_interactively() {
     let result = entrypoint(args, &mut buffer, MockTerminal, event);
     assert!(result.is_ok());
     assert_eq!(
-        buffer,
+        buffer.normalize_path(),
         buf!(
             b"\x1b[?1049h\x1b[0m\x1b[1;1H\x1b[JSearch: \x1b7\x1b[1E\
             >\x20.browserslistrc\x1b[1E\
@@ -296,7 +251,6 @@ fn show_filtered_paths_with_query_interactively() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn show_filtered_paths_with_query_interactively_including_backspace() {
     let dir = create_tree().unwrap();
     let args = args![
@@ -316,7 +270,7 @@ fn show_filtered_paths_with_query_interactively_including_backspace() {
     let result = entrypoint(args, &mut buffer, MockTerminal, event);
     assert!(result.is_ok());
     assert_eq!(
-        buffer,
+        buffer.normalize_path(),
         buf!(
             b"\x1b[?1049h\x1b[0m\x1b[1;1H\
             \x1b[JSearch: \x1b7\x1b[1E\

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -43,8 +43,19 @@ pub struct MockTerminalEvent {
 }
 
 impl Buffer {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self { inner: vec![] }
+    }
+
+    #[allow(dead_code)]
+    pub fn normalize_path(mut self) -> Self {
+        for value in self.inner.iter_mut() {
+            if *value == b'\\' {
+                *value = b'/';
+            }
+        }
+        Self { inner: self.inner }
     }
 }
 
@@ -116,12 +127,14 @@ impl Terminal for MockTerminal {
 }
 
 impl MockTerminalEvent {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             events: Arc::new(Mutex::new(VecDeque::new())),
         }
     }
 
+    #[allow(dead_code)]
     pub fn add(&mut self, event: Option<Event>) {
         let data = self.events.clone();
         let mut events = data.lock().unwrap();
@@ -160,6 +173,7 @@ impl TerminalEvent for MockTerminalEvent {
     }
 }
 
+#[allow(dead_code)]
 pub fn create_tree() -> io::Result<TempDir> {
     let tmp = tempdir()?;
     create_dir_all(tmp.path().join("src/a/b/c"))?;


### PR DESCRIPTION
This is a part of #121


This new function is responsible for replacing `'\\'` with `'/'` to test
the `cli` module with the same test cases on both Windows and Unix.