### PR TITLE
Remove refactoring comment in cli.rb

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-// TODO: This file requires refactoring, but first I want to make sure the behavior is expected through testing.
 use std::ffi::{CString, OsString};
 use std::io::{self, Stderr, Stdout, Write};
 use std::os::raw::c_char;


### PR DESCRIPTION
Now, I feel OK to go on with the current implementation for `cli.rb`, so I just removed the comment.