### PR TITLE
Ignore error paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -289,8 +289,10 @@ fn find_paths(starting_point: &StartingPoint, query: &str, limit: u16) -> Result
 
     for path in Finder::new(starting_point, query)? {
         // TODO: Shouldn't we stop iteration when some paths returns Err?
-        let path = path?;
-        paths.push(path);
+        match path {
+            Ok(path) => paths.push(path),
+            Err(_) => (), // TODO: Output failed paths to a log file.
+        }
     }
 
     paths.sort();


### PR DESCRIPTION
Fix #198 

A directory sometimes includes directories that cannot be read.
Previously, if the starting point contains such directories, this
program exits as status 1. This might be inconvenient.

So, this patch makes thwack skip such directories.