### PR TITLE
Respect .gitignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +58,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.13.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,10 +101,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -80,6 +156,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mio"
@@ -134,6 +216,18 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "redox_syscall"
@@ -214,11 +308,42 @@ name = "thwack"
 version = "0.4.11"
 dependencies = [
  "crossterm",
+ "git2",
  "libc",
  "log",
  "tempfile",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -232,6 +357,24 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.4.11"
 
 [dependencies]
 crossterm = "0.23.0"
+git2 = { version = "0.13.25", default-features = false }
 libc = "0.2.118"
 log = { version = "0.4.14", features = ["std"] }
 unicode-segmentation = "1.9.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -565,6 +565,19 @@ mod tests {
     }
 
     #[test]
+    fn parser_with_no_gitignore() {
+        assert_eq!(
+            Parser::new(args!["program", "--no-gitignore"])
+                .parse()
+                .unwrap(),
+            ParsedArgs {
+                gitignore: false,
+                ..default!()
+            }
+        );
+    }
+
+    #[test]
     fn parser_with_starting_point_disallow_option_like_value() {
         assert_eq!(
             Parser::new(args!["program", "--starting-point", "--option-like-value"])

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,7 @@ pub fn entrypoint<A: Iterator<Item = OsString>, W: Write>(
     }
 
     let repo = if args.gitignore {
-        match Repository::open(&args.starting_point) {
+        match Repository::discover(&args.starting_point) {
             Ok(r) => Some(r),
             Err(_) => {
                 log::info!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,7 @@ pub fn entrypoint<A: Iterator<Item = OsString>, W: Write>(
     }
 
     let repo = if args.gitignore {
-        match Repository::discover(&args.starting_point) {
+        match Repository::open(&args.starting_point) {
             Ok(r) => Some(r),
             Err(_) => {
                 log::info!(

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -194,6 +194,12 @@ mod tests {
         let target = head.target().unwrap();
         let commit = repo.find_commit(target).unwrap();
         let tree = repo.find_tree(commit.tree_id()).unwrap();
+        let statuses = repo
+            .statuses(Some(&mut git2::StatusOptions::new()))
+            .unwrap();
+        for entry in statuses.iter() {
+            println!("{:?}", entry.path());
+        }
         let _ = repo
             .commit(
                 Some("HEAD"),

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -155,8 +155,8 @@ mod tests {
         create_dir_all(tmp.path().join("src/a/b/c"))?;
         create_dir_all(tmp.path().join("lib/a/b/c"))?;
         create_dir_all(tmp.path().join(".config"))?;
-        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt")?;
-        let _ = File::create(tmp.path().join("log.txt"))?;
+        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"LOG")?;
+        let _ = File::create(tmp.path().join("LOG"))?;
         let _ = File::create(tmp.path().join(".browserslistrc"))?;
         let _ = File::create(tmp.path().join(".config/bar.toml"))?;
         let _ = File::create(tmp.path().join(".config/ok.toml"))?;
@@ -228,7 +228,7 @@ mod tests {
         let dir = create_tree().unwrap();
         let paths = find_paths(dir.path().to_str().unwrap(), "", None);
         assert!(paths.contains(&".git/config".to_string()));
-        assert!(paths.contains(&"log.txt".to_string()));
+        assert!(paths.contains(&"LOG".to_string()));
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
         println!("{:?}", paths);
         assert_eq!(paths.len(), 29);
         assert!(!paths.contains(&".git/config".to_string()));
-        assert!(!paths.contains(&"log.txt".to_string()));
+        assert!(!paths.contains(&"LOG".to_string()));
     }
 
     #[test]

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -199,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_all_paths() {
+    fn includes_gitignore_paths() {
         let dir = create_tree().unwrap();
         let paths = find_paths(dir.path().to_str().unwrap(), "", None);
         assert!(paths.contains(&".git/config".to_string()));
@@ -207,11 +207,10 @@ mod tests {
     }
 
     #[test]
-    fn returns_all_paths_excluding_git() {
+    fn excludes_gitignore_paths() {
         let dir = create_tree().unwrap();
         let repo = Some(Repository::open(dir.path()).unwrap());
         let paths = find_paths(dir.path().to_str().unwrap(), "", repo.as_ref());
-        assert_eq!(paths.len(), 29);
         assert!(!paths.contains(&".git/config".to_string()));
         assert!(!paths.contains(&".log.txt".to_string()));
     }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -202,7 +202,6 @@ mod tests {
     fn returns_all_paths() {
         let dir = create_tree().unwrap();
         let paths = find_paths(dir.path().to_str().unwrap(), "", None);
-        assert_eq!(paths.len(), 40);
         assert!(paths.contains(&".git/config".to_string()));
         assert!(paths.contains(&".log.txt".to_string()));
     }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -81,6 +81,7 @@ impl ConsumedDir {
             if let Some(r) = repo {
                 match r.is_path_ignored(&path) {
                     Ok(result) => {
+                        println!("{:?}={:?}", &path, result);
                         if result {
                             continue;
                         }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -194,12 +194,6 @@ mod tests {
         let target = head.target().unwrap();
         let commit = repo.find_commit(target).unwrap();
         let tree = repo.find_tree(commit.tree_id()).unwrap();
-        let statuses = repo
-            .statuses(Some(&mut git2::StatusOptions::new()))
-            .unwrap();
-        for entry in statuses.iter() {
-            println!("{:?}", entry.path());
-        }
         let _ = repo
             .commit(
                 Some("HEAD"),
@@ -239,8 +233,14 @@ mod tests {
     #[test]
     fn excludes_gitignore_paths() {
         let dir = create_tree().unwrap();
-        let repo = Some(Repository::open(dir.path()).unwrap());
-        let paths = find_paths(dir.path().to_str().unwrap(), "", repo.as_ref());
+        let repo = Repository::open(dir.path()).unwrap();
+        let statuses = repo
+            .statuses(Some(&mut git2::StatusOptions::new()))
+            .unwrap();
+        for entry in statuses.iter() {
+            println!("{:?}", entry.path());
+        }
+        let paths = find_paths(dir.path().to_str().unwrap(), "", Some(&repo));
         assert_eq!(paths.len(), 29);
         assert!(!paths.contains(&".git/config".to_string()));
         assert!(!paths.contains(&"log.txt".to_string()));

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -166,6 +166,10 @@ mod tests {
         let _ = File::create(tmp.path().join("tsconfig.json"))?;
         let _ = File::create(tmp.path().join("☕.txt"))?;
         let repo = Repository::init(tmp.path()).unwrap();
+        repo.config()
+            .unwrap()
+            .set_bool("core.autocrlf", true)
+            .unwrap();
         let signature = Signature::now("test", "test@example.com").unwrap();
         let tree = repo
             .find_tree(repo.index().unwrap().write_tree().unwrap())

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::path::Path;
 
+use git2::Repository;
+
 use crate::error::{Error, Result};
 use crate::matched_path::MatchedPath;
 use crate::starting_point::StartingPoint;
@@ -9,17 +11,23 @@ pub(crate) struct Finder<'a> {
     starting_point: &'a StartingPoint,
     query: &'a str,
     dirs: VecDeque<ConsumedDir>,
+    repo: Option<&'a Repository>,
 }
 
 impl<'a> Finder<'a> {
-    pub(crate) fn new(starting_point: &'a StartingPoint, query: &'a str) -> Result<Self> {
+    pub(crate) fn new(
+        starting_point: &'a StartingPoint,
+        query: &'a str,
+        repo: Option<&'a Repository>,
+    ) -> Result<Self> {
         let mut dirs = VecDeque::with_capacity(100);
-        let consumed_dir = ConsumedDir::new(starting_point.as_ref())?;
+        let consumed_dir = ConsumedDir::new(starting_point.as_ref(), repo)?;
         dirs.push_back(consumed_dir);
         Ok(Self {
             starting_point,
             query,
             dirs,
+            repo,
         })
     }
 }
@@ -32,7 +40,7 @@ impl<'a> Iterator for Finder<'a> {
             let dir = self.dirs.front_mut()?;
             let absolute = match dir.next() {
                 Some(Entry::File(path)) => path,
-                Some(Entry::Dir(path)) => match ConsumedDir::new(&path) {
+                Some(Entry::Dir(path)) => match ConsumedDir::new(&path, self.repo) {
                     Ok(c) => {
                         self.dirs.push_back(c);
                         continue;
@@ -65,11 +73,24 @@ struct ConsumedDir {
 
 impl ConsumedDir {
     /// `ConsumedDir::new` assumes the passed `root` has already been canonicalized.
-    fn new(root: &str) -> Result<Self> {
+    fn new(root: &str, repo: Option<&Repository>) -> Result<Self> {
         let mut entries = VecDeque::with_capacity(50);
         let dir: &Path = root.as_ref();
         for de in dir.read_dir()? {
             let path = de?.path();
+            if let Some(r) = repo {
+                match r.is_path_ignored(&path) {
+                    Ok(result) => {
+                        if result {
+                            continue;
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("is_path_ignored failed: {:?}", e);
+                        continue;
+                    }
+                }
+            }
             let path_string = match path.to_str() {
                 Some(path) => path.to_string(),
                 None => {
@@ -102,7 +123,9 @@ impl Iterator for ConsumedDir {
 mod tests {
     use std::fs::{create_dir_all, File};
     use std::io;
+    use std::io::Write;
 
+    use git2::{Repository, Signature};
     use tempfile::{tempdir, TempDir};
 
     use super::*;
@@ -112,13 +135,14 @@ mod tests {
         create_dir_all(tmp.path().join("src/a/b/c"))?;
         create_dir_all(tmp.path().join("lib/a/b/c"))?;
         create_dir_all(tmp.path().join(".config"))?;
+        let _ = File::create(tmp.path().join(".log.txt"))?;
         let _ = File::create(tmp.path().join(".browserslistrc"))?;
         let _ = File::create(tmp.path().join(".config/bar.toml"))?;
         let _ = File::create(tmp.path().join(".config/ok.toml"))?;
         let _ = File::create(tmp.path().join(".editorconfig"))?;
         let _ = File::create(tmp.path().join(".env"))?;
         let _ = File::create(tmp.path().join(".env.local"))?;
-        let _ = File::create(tmp.path().join(".gitignore"))?;
+        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b".log.txt")?;
         let _ = File::create(tmp.path().join(".npmrc"))?;
         let _ = File::create(tmp.path().join(".nvmrc"))?;
         let _ = File::create(tmp.path().join("Dockerfile"))?;
@@ -141,13 +165,28 @@ mod tests {
         let _ = File::create(tmp.path().join("src/index.js"))?;
         let _ = File::create(tmp.path().join("tsconfig.json"))?;
         let _ = File::create(tmp.path().join("☕.txt"))?;
+        let repo = Repository::init(tmp.path()).unwrap();
+        let signature = Signature::now("test", "test@example.com").unwrap();
+        let tree = repo
+            .find_tree(repo.index().unwrap().write_tree().unwrap())
+            .unwrap();
+        let _ = repo
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "Initial commit",
+                &tree,
+                &[],
+            )
+            .unwrap();
         Ok(tmp)
     }
 
-    fn find_paths(starting_point: &str, query: &str) -> Vec<String> {
+    fn find_paths(starting_point: &str, query: &str, repo: Option<&Repository>) -> Vec<String> {
         let starting_point = StartingPoint::new(starting_point).unwrap();
         let mut paths = vec![];
-        for matched in Finder::new(&starting_point, query).unwrap() {
+        for matched in Finder::new(&starting_point, query, repo).unwrap() {
             let path = matched.unwrap();
             paths.push(path);
         }
@@ -162,16 +201,30 @@ mod tests {
     #[test]
     fn returns_all_paths() {
         let dir = create_tree().unwrap();
-        let size = find_paths(dir.path().to_str().unwrap(), "").len();
-        assert_eq!(size, 29);
+        let paths = find_paths(dir.path().to_str().unwrap(), "", None);
+        assert_eq!(paths.len(), 40);
+        assert!(paths.contains(&".git/config".to_string()));
+        assert!(paths.contains(&".log.txt".to_string()));
+    }
+
+    #[test]
+    fn returns_all_paths_excluding_git() {
+        let dir = create_tree().unwrap();
+        let repo = Some(Repository::open(dir.path()).unwrap());
+        let paths = find_paths(dir.path().to_str().unwrap(), "", repo.as_ref());
+        assert_eq!(paths.len(), 29);
+        assert!(!paths.contains(&".git/config".to_string()));
+        assert!(!paths.contains(&".log.txt".to_string()));
     }
 
     #[test]
     fn returns_empty() {
         let dir = create_tree().unwrap();
+        let repo = Some(Repository::open(dir.path()).unwrap());
         let size = find_paths(
             dir.path().to_str().unwrap(),
             "the word should be not found with 🎂",
+            repo.as_ref(),
         )
         .len();
         assert_eq!(size, 0);
@@ -180,14 +233,16 @@ mod tests {
     #[test]
     fn returns_filtered_paths_with_only_separator() {
         let dir = create_tree().unwrap();
-        let size = find_paths(dir.path().to_str().unwrap(), "/").len();
+        let repo = Some(Repository::open(dir.path()).unwrap());
+        let size = find_paths(dir.path().to_str().unwrap(), "/", repo.as_ref()).len();
         assert_eq!(size, 15);
     }
 
     #[test]
     fn returns_filtered_paths_with_uppercase() {
         let dir = create_tree().unwrap();
-        let paths = find_paths(dir.path().to_str().unwrap(), "licenSE");
+        let repo = Some(Repository::open(dir.path()).unwrap());
+        let paths = find_paths(dir.path().to_str().unwrap(), "licenSE", repo.as_ref());
         assert_eq!(paths.len(), 1);
         assert_eq!(paths, vec!["LICENSE"]);
     }
@@ -195,7 +250,8 @@ mod tests {
     #[test]
     fn returns_filtered_paths_with_emoji_coffee() {
         let dir = create_tree().unwrap();
-        let paths = find_paths(dir.path().to_str().unwrap(), "☕");
+        let repo = Some(Repository::open(dir.path()).unwrap());
+        let paths = find_paths(dir.path().to_str().unwrap(), "☕", repo.as_ref());
         assert_eq!(paths.len(), 3);
         assert_eq!(paths, vec!["lib/a/b/c/☕.js", "src/a/☕.js", "☕.txt"]);
     }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -135,14 +135,14 @@ mod tests {
         create_dir_all(tmp.path().join("src/a/b/c"))?;
         create_dir_all(tmp.path().join("lib/a/b/c"))?;
         create_dir_all(tmp.path().join(".config"))?;
-        let _ = File::create(tmp.path().join(".log.txt"))?;
+        let _ = File::create(tmp.path().join("log.txt"))?;
         let _ = File::create(tmp.path().join(".browserslistrc"))?;
         let _ = File::create(tmp.path().join(".config/bar.toml"))?;
         let _ = File::create(tmp.path().join(".config/ok.toml"))?;
         let _ = File::create(tmp.path().join(".editorconfig"))?;
         let _ = File::create(tmp.path().join(".env"))?;
         let _ = File::create(tmp.path().join(".env.local"))?;
-        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b".log.txt")?;
+        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt")?;
         let _ = File::create(tmp.path().join(".npmrc"))?;
         let _ = File::create(tmp.path().join(".nvmrc"))?;
         let _ = File::create(tmp.path().join("Dockerfile"))?;
@@ -203,7 +203,7 @@ mod tests {
         let dir = create_tree().unwrap();
         let paths = find_paths(dir.path().to_str().unwrap(), "", None);
         assert!(paths.contains(&".git/config".to_string()));
-        assert!(paths.contains(&".log.txt".to_string()));
+        assert!(paths.contains(&"log.txt".to_string()));
     }
 
     #[test]
@@ -211,8 +211,9 @@ mod tests {
         let dir = create_tree().unwrap();
         let repo = Some(Repository::open(dir.path()).unwrap());
         let paths = find_paths(dir.path().to_str().unwrap(), "", repo.as_ref());
+        assert_eq!(paths.len(), 29);
         assert!(!paths.contains(&".git/config".to_string()));
-        assert!(!paths.contains(&".log.txt".to_string()));
+        assert!(!paths.contains(&"log.txt".to_string()));
     }
 
     #[test]

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -125,7 +125,7 @@ mod tests {
     use std::io;
     use std::io::Write;
 
-    use git2::{Repository, Signature};
+    use git2::{Repository, Signature, StatusOptions};
     use tempfile::{tempdir, TempDir};
 
     use super::*;
@@ -235,8 +235,9 @@ mod tests {
         let dir = create_tree().unwrap();
         let repo = Repository::open(dir.path()).unwrap();
         let statuses = repo
-            .statuses(Some(&mut git2::StatusOptions::new()))
+            .statuses(Some(&mut StatusOptions::new().include_untracked(true)))
             .unwrap();
+        println!("test!!");
         for entry in statuses.iter() {
             println!("{:?}", entry.path());
         }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -237,11 +237,11 @@ mod tests {
         let statuses = repo
             .statuses(Some(&mut StatusOptions::new().include_untracked(true)))
             .unwrap();
-        println!("test!!");
         for entry in statuses.iter() {
             println!("{:?}", entry.path());
         }
         let paths = find_paths(dir.path().to_str().unwrap(), "", Some(&repo));
+        println!("{:?}", paths);
         assert_eq!(paths.len(), 29);
         assert!(!paths.contains(&".git/config".to_string()));
         assert!(!paths.contains(&"log.txt".to_string()));

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -142,7 +142,7 @@ mod tests {
         let _ = File::create(tmp.path().join(".editorconfig"))?;
         let _ = File::create(tmp.path().join(".env"))?;
         let _ = File::create(tmp.path().join(".env.local"))?;
-        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt")?;
+        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt\r\n")?;
         let _ = File::create(tmp.path().join(".npmrc"))?;
         let _ = File::create(tmp.path().join(".nvmrc"))?;
         let _ = File::create(tmp.path().join("Dockerfile"))?;
@@ -166,10 +166,6 @@ mod tests {
         let _ = File::create(tmp.path().join("tsconfig.json"))?;
         let _ = File::create(tmp.path().join("☕.txt"))?;
         let repo = Repository::init(tmp.path()).unwrap();
-        repo.config()
-            .unwrap()
-            .set_bool("core.autocrlf", true)
-            .unwrap();
         let signature = Signature::now("test", "test@example.com").unwrap();
         let tree = repo
             .find_tree(repo.index().unwrap().write_tree().unwrap())

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -135,6 +135,7 @@ mod tests {
         create_dir_all(tmp.path().join("src/a/b/c"))?;
         create_dir_all(tmp.path().join("lib/a/b/c"))?;
         create_dir_all(tmp.path().join(".config"))?;
+        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt\r\n")?;
         let _ = File::create(tmp.path().join("log.txt"))?;
         let _ = File::create(tmp.path().join(".browserslistrc"))?;
         let _ = File::create(tmp.path().join(".config/bar.toml"))?;
@@ -142,7 +143,6 @@ mod tests {
         let _ = File::create(tmp.path().join(".editorconfig"))?;
         let _ = File::create(tmp.path().join(".env"))?;
         let _ = File::create(tmp.path().join(".env.local"))?;
-        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt\r\n")?;
         let _ = File::create(tmp.path().join(".npmrc"))?;
         let _ = File::create(tmp.path().join(".nvmrc"))?;
         let _ = File::create(tmp.path().join("Dockerfile"))?;


### PR DESCRIPTION
In most cases, it's rare to search files that are listed in `.gitignore`
or files in `.git/`. This patch introduces `git2` and lets us ignore
files that are listed in `.gitignore`.