### PR TITLE
Rename args.rs to preferences.rs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,7 @@ pub fn entrypoint<A: Iterator<Item = OsString>, W: Write>(
     terminal: impl Terminal,
     mut event: impl TerminalEvent,
 ) -> Result<()> {
-    let preferences = PreferencesParser::parse_args(args)?;
+    let preferences = PreferencesParser::new(args).parse_args()?;
     if let Some(ref path) = preferences.log_file {
         logger::init(path)?;
         log::debug!("Logger initialized!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
-pub use args::HELP;
 pub use cli::{entrypoint, safe_exit};
 pub use error::{Error, ErrorKind, Result};
+pub use preferences::HELP;
 pub use terminal::{DefaultTerminal, DefaultTerminalEvent, Terminal, TerminalEvent};
 
-mod args;
 mod cli;
 mod error;
 mod finder;
 mod logger;
 mod matched_path;
+mod preferences;
 mod starting_point;
 mod terminal;


### PR DESCRIPTION
This patch tries to rename `args.rs` to `preferences.rs`.

I'm planning to make thwack see environment variables for the
configuration. So, `args.rs` might be not a bit appropriate to support
such features in this module.