### PR TITLE
Migrate the edition from 2018 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ homepage = "https://github.com/yykamei/thwack"
 repository = "https://github.com/yykamei/thwack"
 license = "MIT OR Apache-2.0"
 categories = ["command-line-utilities"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.59.0"
 version = "0.6.0"
 
 [dependencies]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::ffi::OsString;
 
 use crate::error::{Error, Result};

--- a/src/status_line.rs
+++ b/src/status_line.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 #[derive(Debug, PartialEq)]
 pub(crate) enum StatusLine {
     Absolute,


### PR DESCRIPTION
Now, we can migrate the Rust edition for thwack from 2018 to 2021.

See https://doc.rust-lang.org/beta/edition-guide/rust-2021/index.html for more details.