### PR TITLE
Make command-line arguments take precedence over envs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub fn entrypoint<A: Iterator<Item = OsString>, W: Write>(
     terminal: impl Terminal,
     mut event: impl TerminalEvent,
 ) -> Result<()> {
-    let preferences = Args::new(args).parse()?.parse_env(env::vars_os());
+    let preferences = Args::new(args, env::vars_os()).parse()?;
 
     if let Some(ref path) = preferences.log_file {
         logger::init(path)?;

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -63,9 +63,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_env() {
-        // NOTE: This test assumes that any thwack specific environment variables are not set.
-        let preferences = Preferences::default().parse_env(std::env::vars_os());
+    fn parse_env_without_thwack_environment_variables() {
+        let preferences = Preferences::default().parse_env([].into_iter());
         assert_eq!(preferences, Preferences::default());
     }
 
@@ -79,7 +78,6 @@ mod tests {
                 ),
                 (OsString::from("THWACK_EXEC"), OsString::from("/bin/echo")),
             ]
-            .to_vec()
             .into_iter(),
         );
         assert_eq!(


### PR DESCRIPTION
I prefer the behavior that command-line arguments take precedence over environment variables, which means `THWACK_EXEC=ls thwack --exec=exa` will execute `exa` instead of `ls` when a user hits the Enter key on a selected path.

Note AWS CLI also does the same way:

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence