### PR TITLE
Fix release.yml to make its cross-compile available

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
           RUN dpkg --add-architecture ${{ matrix.cross-arch }}
           RUN apt-get update && \
               apt-get install --yes --no-install-recommends \
-                libx11-xcb-dev:${{ matrix.cross-arch }} \
+                libxcb1-dev:${{ matrix.cross-arch }} \
+                libxcb-render0-dev:${{ matrix.cross-arch }} \
                 libxcb-shape0-dev:${{ matrix.cross-arch }} \
                 libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
                 ;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,14 @@ jobs:
           RUN dpkg --add-architecture ${{ matrix.cross-arch }}
           RUN apt-get update && \
               apt-get install --yes --no-install-recommends \
-                libc6-dev:${{ matrix.cross-arch }} \
                 libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
                 libxcb-composite0-dev:${{ matrix.cross-arch }} \
                 libxcb-damage0-dev:${{ matrix.cross-arch }} \
                 ;
           ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-L /usr/lib/aarch64-linux-gnu ${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS}"
+          ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/aarch64-linux-gnu ${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS}"
           ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf ${CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS}"
+          ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf ${CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS}"
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           RUN dpkg --add-architecture ${{ matrix.cross-arch }}
           RUN apt-get update && \
               apt-get install --yes --no-install-recommends \
+                libc6-dev:${{ matrix.cross-arch }} \
                 libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
                 libxcb-composite0-dev:${{ matrix.cross-arch }} \
                 libxcb-damage0-dev:${{ matrix.cross-arch }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
                 libxcb-composite0-dev:${{ matrix.cross-arch }} \
                 libxcb-damage0-dev:${{ matrix.cross-arch }} \
                 ;
-          ENV LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
-          ENV LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
+          ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-L /usr/lib/aarch64-linux-gnu ${CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS}"
+          ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf ${CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS}"
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             suffix: .tar.gz
-            cross: 'true'
+            cross-arch: 'arm64'
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
             suffix: .tar.gz
-            cross: 'true'
+            cross-arch: 'armhf'
           - target: x86_64-apple-darwin
             os: macOS-latest
             suffix: .tar.gz
@@ -50,10 +50,11 @@ jobs:
         run: |
           cat <<EOD > Dockerfile
           FROM ghcr.io/cross-rs/${{ matrix.target }}:main
+          RUN dpkg --add-architecture ${{ matrix.cross-arch }}
           RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
           EOD
           docker build -t ${{ matrix.target }}:main .
-        if: matrix.cross == 'true'
+        if: matrix.cross-arch
 
       - uses: actions/checkout@v3
 
@@ -68,7 +69,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: ${{ matrix.cross == 'true' }}
+          use-cross: ${{ matrix.cross-arch }}
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: matrix.os == 'true'
+          use-cross: matrix.cross == 'true'
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: ${{ matrix.cross-arch }}
+          use-cross: ${{ !!matrix.cross-arch }}
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,15 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             suffix: .tar.gz
+            cross: 'true'
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             suffix: .tar.gz
+            cross: 'true'
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
             suffix: .tar.gz
+            cross: 'true'
           - target: x86_64-apple-darwin
             os: macOS-latest
             suffix: .tar.gz
@@ -41,8 +44,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - run: sudo apt-get install libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
-        if: matrix.os == 'ubuntu-latest'
+      - name: Create Dockerfile
+        run: |
+          cat <<EOD > Dockerfile
+          FROM ghcr.io/cross-rs/${{ matrix.target }}:main
+          RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          EOD
+          docker build -t ${{ matrix.target }}:main
+        if: matrix.cross == 'true'
 
       - uses: actions/checkout@v3
 
@@ -57,7 +66,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+          use-cross: matrix.cross == 'true'
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,10 @@ jobs:
           RUN dpkg --add-architecture ${{ matrix.cross-arch }}
           RUN apt-get update && \
               apt-get install --yes --no-install-recommends \
-                libxcb1-dev:${{ matrix.cross-arch }} \
-                libxcb-render0-dev:${{ matrix.cross-arch }} \
-                libxcb-shape0-dev:${{ matrix.cross-arch }} \
                 libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
+                libxcb-composite0-dev:${{ matrix.cross-arch }} \
+                libxcb-damage0-dev:${{ matrix.cross-arch }} \
                 ;
-          ENV LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
                 libxcb-shape0-dev:${{ matrix.cross-arch }} \
                 libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
                 ;
-          ENV LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
+          ENV LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
                 libxcb-shape0-dev:${{ matrix.cross-arch }} \
                 libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
                 ;
+          ENV LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - run: apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev musl-tools
+      - run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev musl-tools
         if: matrix.os == 'ubuntu-latest'
 
       - name: Create Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: matrix.cross == 'true'
+          use-cross: ${{ matrix.cross == 'true' }}
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,12 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             suffix: .tar.gz
-            cross: 'true'
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             suffix: .tar.gz
-            cross: 'true'
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
             suffix: .tar.gz
-            cross: 'true'
           - target: x86_64-apple-darwin
             os: macOS-latest
             suffix: .tar.gz
@@ -51,7 +48,7 @@ jobs:
           RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
           EOD
           docker build -t ${{ matrix.target }}:main
-        if: matrix.cross == 'true'
+        if: matrix.os == 'ubuntu-latest'
 
       - uses: actions/checkout@v3
 
@@ -66,7 +63,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: matrix.cross == 'true'
+          use-cross: matrix.os == 'ubuntu-latest'
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,12 @@ jobs:
           cat <<EOD > Dockerfile
           FROM ghcr.io/cross-rs/${{ matrix.target }}:main
           RUN dpkg --add-architecture ${{ matrix.cross-arch }}
-          RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          RUN apt-get update && \
+              apt-get install --yes --no-install-recommends \
+                libx11-xcb-dev:${{ matrix.cross-arch }} \
+                libxcb-shape0-dev:${{ matrix.cross-arch }} \
+                libxcb-xfixes0-dev:${{ matrix.cross-arch }} \
+                ;
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
                 libxcb-composite0-dev:${{ matrix.cross-arch }} \
                 libxcb-damage0-dev:${{ matrix.cross-arch }} \
                 ;
+          ENV LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
+          ENV LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib/arm-linux-gnueabihf
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.cross-arch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           cat <<EOD > Dockerfile
           FROM ghcr.io/cross-rs/${{ matrix.target }}:main
-          RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,11 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             suffix: .tar.gz
+            cross: 'true'
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
             suffix: .tar.gz
+            cross: 'true'
           - target: x86_64-apple-darwin
             os: macOS-latest
             suffix: .tar.gz
@@ -41,15 +43,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
+      - run: apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev musl-tools
+        if: matrix.os == 'ubuntu-latest'
+
       - name: Create Dockerfile
         run: |
           cat <<EOD > Dockerfile
           FROM ghcr.io/cross-rs/${{ matrix.target }}:main
-          USER root
           RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
           EOD
           docker build -t ${{ matrix.target }}:main .
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.cross == 'true'
 
       - uses: actions/checkout@v3
 
@@ -64,7 +68,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.target }}
-          use-cross: matrix.os == 'ubuntu-latest'
+          use-cross: matrix.os == 'true'
 
       - name: Bundle on Windows
         run: 7z a ../../../thwack-${{ matrix.target }}${{ matrix.suffix }} thwack.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           cat <<EOD > Dockerfile
           FROM ghcr.io/cross-rs/${{ matrix.target }}:main
-          RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          USER root
+          RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
           EOD
           docker build -t ${{ matrix.target }}:main .
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           FROM ghcr.io/cross-rs/${{ matrix.target }}:main
           RUN apt-get update && apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
           EOD
-          docker build -t ${{ matrix.target }}:main
+          docker build -t ${{ matrix.target }}:main .
         if: matrix.os == 'ubuntu-latest'
 
       - uses: actions/checkout@v3

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+[target.x86_64-unknown-linux-musl]
+image = "x86_64-unknown-linux-musl:main"
+
+[target.aarch64-unknown-linux-musl]
+image = "aarch64-unknown-linux-musl:main"
+
+[target.arm-unknown-linux-musleabihf]
+image = "arm-unknown-linux-musleabihf:main"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,9 +1,3 @@
-[target.x86_64-unknown-linux-gnu]
-image = "x86_64-unknown-linux-gnu:main"
-
-[target.x86_64-unknown-linux-musl]
-image = "x86_64-unknown-linux-musl:main"
-
 [target.aarch64-unknown-linux-musl]
 image = "aarch64-unknown-linux-musl:main"
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[target.x86_64-unknown-linux-gnu]
+image = "x86_64-unknown-linux-gnu:main"
+
 [target.x86_64-unknown-linux-musl]
 image = "x86_64-unknown-linux-musl:main"
 


### PR DESCRIPTION
I want to fix this failure.

https://github.com/yykamei/thwack/actions/runs/2037357112

As far as I see the documentation of [cross](https://github.com/cross-rs/cross), I think I have to create a container image before running `actions-rs/cargo`.

This is the successor of #245.