### PR TITLE
Fix to consider the resize of terminal

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -251,6 +251,7 @@ impl<'a, W: Write, T: Terminal, TE: TerminalEvent> Runner<'a, W, T, TE> {
                 } else if let Event::Resize(c, r) = ev {
                     self.max_columns = c;
                     self.max_rows = r;
+                    self.writer.resize(r, c);
                     self.selection = if self.selection > r {
                         self.paths_rows(r) - 1
                     } else {
@@ -345,6 +346,13 @@ impl<'a, W: Write, T: Terminal> Writer<'a, W, T> {
             max_rows,
             max_path_width: (max_columns - 2).into(), // The prefix "> " requires 2 columns.
         }
+    }
+
+    fn resize(&mut self, max_rows: u16, max_columns: u16) -> &Self {
+        self.max_rows = max_rows;
+        self.max_columns = max_columns;
+        self.max_path_width = (max_columns - 2).into(); // The prefix "> " requires 2 columns.
+        self
     }
 
     fn output(&mut self, query: &str, selection: u16, paths: &[MatchedPath]) -> Result<()> {

--- a/tests/change_selection.rs
+++ b/tests/change_selection.rs
@@ -23,7 +23,6 @@ fn cannot_move_up_because_selection_reaches_to_top() {
     event.add(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
     let result = entrypoint(args, &mut buffer, MockTerminal, event);
-    println!("{:?}", result);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),

--- a/tests/handle_resize.rs
+++ b/tests/handle_resize.rs
@@ -1,0 +1,75 @@
+use std::ffi::OsString;
+
+use crossterm::event::{Event, KeyCode};
+
+use helper::{create_tree, MockTerminal, MockTerminalEvent};
+use thwack::entrypoint;
+
+mod helper;
+
+#[test]
+fn handle_resize() {
+    let dir = create_tree().unwrap();
+    let args = args![
+        "thwack",
+        "--starting-point",
+        dir.path().to_str().unwrap(),
+        "--status-line=relative"
+    ];
+    let mut event = MockTerminalEvent::new();
+    event.add(Some(Event::Resize(14, 20)));
+    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut buffer = buf!();
+    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    assert!(result.is_ok());
+    assert_eq!(
+        buffer.normalize_path(),
+        buf!(
+            b"\x1b[?1049h\x1b[0m",
+            b"\x1b[1;1H\x1b[J",
+            b"Search: \x1b7\x1b[1E",
+            b"> .browserslistrc\x1b[1E",
+            b"  .config/bar.toml\x1b[1E",
+            b"  .config/ok.toml\x1b[1E",
+            b"  .editorconfig\x1b[1E",
+            b"  .env\x1b[1E",
+            b"  .env.local\x1b[1E",
+            b"  .gitignore\x1b[1E",
+            b"  .npmrc\x1b[1E",
+            b"  .nvmrc\x1b[1E",
+            b"  Dockerfile\x1b[1E",
+            b"  LICENSE\x1b[1E",
+            b"  README.md\x1b[1E",
+            b"  lib/a/b/c/index.js\x1b[1E",
+            b"  lib/a/b/c/\xe2\x98\x95.js\x1b[1E",
+            b"  lib/a/b/index.js\x1b[1E",
+            b"  lib/a/index.js\x1b[1E",
+            b"  lib/bar.js\x1b[1E",
+            b"\x1b[19d\x1b[1m\x1b[7m.browserslistrc                                                                                   \x1b[0m\x1b[1E",
+            b"\x1b[1m<Up>/<Ctrl-p>:\x1b[0m\x1b[1CUp\x1b[2C\x1b[1m<Down>/<Ctrl-n>:\x1b[0m\x1b[1CDown\x1b[2C\x1b[1m<Enter>:\x1b[0m\x1b[1CExecute\x1b[2C\x1b[1m<C-d>/<C-y>:\x1b[0m\x1b[1CCopy (relative/absolute)",
+            b"\x1b8",
+            b"\x1b[1;1H\x1b[J",
+            b"Search: \x1b7\x1b[1E",
+            b"> ...erslistrc\x1b[1E",
+            b"  .../bar.toml\x1b[1E",
+            b"  ...g/ok.toml\x1b[1E",
+            b"  ...torconfig\x1b[1E",
+            b"  .env\x1b[1E",
+            b"  .env.local\x1b[1E",
+            b"  .gitignore\x1b[1E",
+            b"  .npmrc\x1b[1E",
+            b"  .nvmrc\x1b[1E",
+            b"  Dockerfile\x1b[1E",
+            b"  LICENSE\x1b[1E",
+            b"  README.md\x1b[1E",
+            b"  .../index.js\x1b[1E",
+            b"  ...b/c/\xe2\x98\x95.js\x1b[1E",
+            b"  .../index.js\x1b[1E",
+            b"  .../index.js\x1b[1E",
+            b"  lib/bar.js\x1b[1E",
+            b"\x1b[19d\x1b[1m\x1b[7m...wserslistrc\x1b[0m",
+            b"\x1b8",
+            b"\x1b[?1049l"
+        )
+    );
+}


### PR DESCRIPTION
With https://github.com/yykamei/thwack/pull/239, the `Resize` event
had been ignored. This patch fixes to consider the resize of terminal.