### PR TITLE
Refactor terminal.rs, integrating TerminalEvent into Terminal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub use args::HELP;
 pub use cli::{entrypoint, safe_exit};
 pub use error::{Error, ErrorKind, Result};
-pub use terminal::{DefaultTerminal, DefaultTerminalEvent, Terminal, TerminalEvent};
+pub use terminal::{DefaultTerminal, Terminal};
 
 mod args;
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,12 @@
 use std::env;
 use std::io::{stderr, stdout};
 
-use thwack::{entrypoint, safe_exit, DefaultTerminal, DefaultTerminalEvent};
+use thwack::{entrypoint, safe_exit, DefaultTerminal};
 
 fn main() {
     let mut out = stdout();
     let err = stderr();
-    match entrypoint(
-        env::args_os(),
-        &mut out,
-        DefaultTerminal,
-        DefaultTerminalEvent,
-    ) {
+    match entrypoint(env::args_os(), &mut out, DefaultTerminal) {
         Ok(_) => safe_exit(0, out, err),
         Err(e) => {
             eprintln!("{}", e); // TODO: Write a more readable error message.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -22,17 +22,13 @@ pub trait Terminal {
         let _ = terminal::disable_raw_mode()?;
         Ok(())
     }
-}
 
-/// TerminalEvent is a wrapper of crossterm::event.
-/// This is intended for mocking terminal-specific functions.
-pub trait TerminalEvent {
     fn poll(&self, timeout: Duration) -> Result<bool> {
         let b = event::poll(timeout)?;
         Ok(b)
     }
 
-    fn read(&mut self) -> Result<Event> {
+    fn read(&self) -> Result<Event> {
         let e = event::read()?;
         Ok(e)
     }
@@ -40,8 +36,4 @@ pub trait TerminalEvent {
 
 pub struct DefaultTerminal;
 
-pub struct DefaultTerminalEvent;
-
 impl Terminal for DefaultTerminal {}
-
-impl TerminalEvent for DefaultTerminalEvent {}

--- a/tests/change_selection.rs
+++ b/tests/change_selection.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use crossterm::event::{Event, KeyCode};
 
-use helper::{create_tree, MockTerminal, MockTerminalEvent};
+use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;
 
 mod helper;
@@ -16,13 +16,13 @@ fn cannot_move_up_because_selection_reaches_to_top() {
         dir.path().to_str().unwrap(),
         "--status-line=relative"
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Up.into())));
-    event.add(Some(Event::Key(KeyCode::Up.into())));
-    event.add(Some(Event::Key(KeyCode::Up.into())));
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Up.into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Up.into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Up.into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),
@@ -130,20 +130,20 @@ fn cannot_move_down_because_selection_reaches_to_bottom() {
         dir.path().to_str().unwrap(),
         "--status-line=relative"
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Char('b').into())));
-    event.add(Some(Event::Key(KeyCode::Char('r').into())));
-    event.add(Some(Event::Key(KeyCode::Char('o').into())));
-    event.add(Some(Event::Key(KeyCode::Char('w').into())));
-    event.add(Some(Event::Key(KeyCode::Char('s').into())));
-    event.add(Some(Event::Key(KeyCode::Char('e').into())));
-    event.add(Some(Event::Key(KeyCode::Char('r').into())));
-    event.add(None);
-    event.add(Some(Event::Key(KeyCode::Down.into())));
-    event.add(Some(Event::Key(KeyCode::Down.into())));
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Char('b').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('r').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('o').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('w').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('s').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('e').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('r').into())));
+    terminal.add_event(None);
+    terminal.add_event(Some(Event::Key(KeyCode::Down.into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Down.into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),

--- a/tests/copy_selection.rs
+++ b/tests/copy_selection.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use copypasta::{ClipboardContext, ClipboardProvider};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
-use helper::{create_tree, MockTerminal, MockTerminalEvent};
+use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;
 
 mod helper;
@@ -18,17 +18,17 @@ fn copy_with_absolute_path() {
         dir.path().to_str().unwrap(),
         "--status-line=relative"
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Down.into())));
-    event.add(Some(Event::Key(KeyEvent {
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Down.into())));
+    terminal.add_event(Some(Event::Key(KeyEvent {
         code: KeyCode::Char('d'),
         modifiers: KeyModifiers::CONTROL,
         kind: KeyEventKind::Press,
         state: KeyEventState::NONE,
     })));
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),

--- a/tests/filter_by_query.rs
+++ b/tests/filter_by_query.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use crossterm::event::{Event, KeyCode};
 
-use helper::{create_tree, MockTerminal, MockTerminalEvent};
+use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;
 
 mod helper;
@@ -16,10 +16,10 @@ fn show_all_as_many_as_the_size_of_terminal_without_query() {
         dir.path().to_str().unwrap(),
         "--status-line=relative"
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),
@@ -61,10 +61,10 @@ fn show_filtered_paths_with_query() {
         "--status-line=relative",
         "browser",
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),
@@ -89,18 +89,18 @@ fn show_filtered_paths_with_query_interactively() {
         dir.path().to_str().unwrap(),
         "--status-line=relative",
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Char('b').into())));
-    event.add(Some(Event::Key(KeyCode::Char('r').into())));
-    event.add(Some(Event::Key(KeyCode::Char('o').into())));
-    event.add(Some(Event::Key(KeyCode::Char('w').into())));
-    event.add(Some(Event::Key(KeyCode::Char('s').into())));
-    event.add(Some(Event::Key(KeyCode::Char('e').into())));
-    event.add(Some(Event::Key(KeyCode::Char('r').into())));
-    event.add(None);
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Char('b').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('r').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('o').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('w').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('s').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('e').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('r').into())));
+    terminal.add_event(None);
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),
@@ -302,15 +302,15 @@ fn show_filtered_paths_with_query_interactively_including_backspace() {
         dir.path().to_str().unwrap(),
         "--status-line=relative",
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Key(KeyCode::Char('B').into())));
-    event.add(Some(Event::Key(KeyCode::Char('r').into())));
-    event.add(None);
-    event.add(Some(Event::Key(KeyCode::Backspace.into())));
-    event.add(None);
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Key(KeyCode::Char('B').into())));
+    terminal.add_event(Some(Event::Key(KeyCode::Char('r').into())));
+    terminal.add_event(None);
+    terminal.add_event(Some(Event::Key(KeyCode::Backspace.into())));
+    terminal.add_event(None);
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),

--- a/tests/handle_resize.rs
+++ b/tests/handle_resize.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use crossterm::event::{Event, KeyCode};
 
-use helper::{create_tree, MockTerminal, MockTerminalEvent};
+use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;
 
 mod helper;
@@ -16,11 +16,11 @@ fn handle_resize() {
         dir.path().to_str().unwrap(),
         "--status-line=relative"
     ];
-    let mut event = MockTerminalEvent::new();
-    event.add(Some(Event::Resize(14, 20)));
-    event.add(Some(Event::Key(KeyCode::Esc.into())));
+    let mut terminal = MockTerminal::new();
+    terminal.add_event(Some(Event::Resize(14, 20)));
+    terminal.add_event(Some(Event::Key(KeyCode::Esc.into())));
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, event);
+    let result = entrypoint(args, &mut buffer, terminal);
     assert!(result.is_ok());
     assert_eq!(
         buffer.normalize_path(),

--- a/tests/show_help.rs
+++ b/tests/show_help.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 
-use helper::{MockTerminal, MockTerminalEvent};
+use helper::MockTerminal;
 use thwack::{entrypoint, HELP};
 
 mod helper;
@@ -9,7 +9,7 @@ mod helper;
 fn show_help() {
     let args = args!["thwack", "--help"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }
@@ -18,7 +18,7 @@ fn show_help() {
 fn show_help_with_version() {
     let args = args!["thwack", "--help", "--version"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }
@@ -27,7 +27,7 @@ fn show_help_with_version() {
 fn show_help_with_query() {
     let args = args!["thwack", "--help", "--", "query"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }
@@ -36,7 +36,7 @@ fn show_help_with_query() {
 fn show_help_with_starting_point() {
     let args = args!["thwack", "--help", "--starting-point=/tmp"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(HELP));
 }

--- a/tests/show_version.rs
+++ b/tests/show_version.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 
-use helper::{MockTerminal, MockTerminalEvent};
+use helper::MockTerminal;
 use thwack::entrypoint;
 
 mod helper;
@@ -13,7 +13,7 @@ fn version() -> String {
 fn show_version() {
     let args = args!["thwack", "--version"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(version()));
 }
@@ -22,7 +22,7 @@ fn show_version() {
 fn show_version_with_query() {
     let args = args!["thwack", "--version", "--", "query"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(version()));
 }
@@ -31,7 +31,7 @@ fn show_version_with_query() {
 fn show_version_with_starting_point() {
     let args = args!["thwack", "--version", "--starting-point=/tmp"];
     let mut buffer = buf!();
-    let result = entrypoint(args, &mut buffer, MockTerminal, MockTerminalEvent::new());
+    let result = entrypoint(args, &mut buffer, MockTerminal::new());
     assert!(result.is_ok());
     assert_eq!(buffer, buf!(version()));
 }


### PR DESCRIPTION
`Terminal` and `TerminalEvent` can be integrated into one trait because they both depend on crossterm APIs. So, I deleted `TerminalEvent` and migrated its functions into `Terminal`.