### PR TITLE
Remove TODO about symbolic link

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -100,7 +100,6 @@ impl ConsumedDir {
                     )));
                 }
             };
-            // TODO: Symbolic link?
             if path.is_dir() {
                 entries.push_back(Entry::Dir(path_string));
             } else {


### PR DESCRIPTION
`std::path::Path::is_dir` and `std::path::Path::is_file` will traverse symbolic links. First, I thought I should skip symbolic links from Finder results, but I reconsidered making thwack traverse files/directories. These APIs will return `false` when symbolic links are broken or not accessbile by a user, so permission problems might not rarely happen. Still, I'm concerned about security issues about traversing, but I decided to keep access to them.