### PR TITLE
Bump rust-version from 1.59.0 to 1.71.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/yykamei/thwack"
 license = "MIT OR Apache-2.0"
 categories = ["command-line-utilities"]
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.71.0"
 version = "0.8.14"
 
 [dependencies]


### PR DESCRIPTION
Update the value of [rust-version field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) from `1.59.0` to `1.71.0`. I want to make sure the binary will be built with the current latest stable version of Rust.