### PR TITLE
Introduce pretty_assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +408,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +555,7 @@ dependencies = [
  "git2",
  "libc",
  "log",
+ "pretty_assertions",
  "tempfile",
  "unicode-segmentation",
  "unicode-width",
@@ -830,3 +847,9 @@ name = "xml-rs"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab77e97b50aee93da431f2cee7cd0f43b4d1da3c408042f2d7d164187774f0a"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 
 [dev-dependencies]
+pretty_assertions = "1.4.0"
 tempfile = "3.8.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -187,6 +187,8 @@ impl<A: Iterator<Item = OsString>> Args<A> {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     macro_rules! args {

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -125,6 +125,7 @@ mod tests {
     use std::io::Write;
 
     use git2::{Repository, Signature};
+    use pretty_assertions::assert_eq;
     use tempfile::{tempdir, TempDir};
 
     use super::*;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -62,6 +62,8 @@ mod tests {
 
     use tempfile::tempdir;
 
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]
@@ -73,7 +75,7 @@ mod tests {
         log::debug!("d!");
         assert_eq!(
             &fs::read_to_string(&path).unwrap(),
-            "[INFO] [thwack::logger::tests:72] test\n[DEBUG] [thwack::logger::tests:73] d!\n"
+            "[INFO] [thwack::logger::tests:74] test\n[DEBUG] [thwack::logger::tests:75] d!\n"
         );
     }
 }

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -242,6 +242,8 @@ fn normalize_query(query: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     fn new(query: &str, starting_point: &str, absolute: &str) -> MatchedPath {

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -60,6 +60,8 @@ impl Default for Preferences {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+
     use super::*;
 
     #[test]

--- a/tests/change_selection.rs
+++ b/tests/change_selection.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 
 use crossterm::event::{Event, KeyCode};
+use pretty_assertions::assert_eq;
 
 use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;

--- a/tests/copy_selection.rs
+++ b/tests/copy_selection.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 
 use copypasta::{ClipboardContext, ClipboardProvider};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+use pretty_assertions::assert_eq;
 
 use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;

--- a/tests/filter_by_query.rs
+++ b/tests/filter_by_query.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 
 use crossterm::event::{Event, KeyCode};
+use pretty_assertions::assert_eq;
 
 use helper::{create_tree, MockTerminal};
 use thwack::entrypoint;

--- a/tests/handle_resize.rs
+++ b/tests/handle_resize.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 use crossterm::event::{Event, KeyCode};
 
 use helper::{create_tree, MockTerminal};
+use pretty_assertions::assert_eq;
 use thwack::entrypoint;
 
 mod helper;

--- a/tests/show_help.rs
+++ b/tests/show_help.rs
@@ -1,5 +1,7 @@
 use std::ffi::OsString;
 
+use pretty_assertions::assert_eq;
+
 use helper::MockTerminal;
 use thwack::{entrypoint, HELP};
 

--- a/tests/show_version.rs
+++ b/tests/show_version.rs
@@ -1,5 +1,7 @@
 use std::ffi::OsString;
 
+use pretty_assertions::assert_eq;
+
 use helper::MockTerminal;
 use thwack::entrypoint;
 


### PR DESCRIPTION
This crate tests itself by seeing the difference between actual output to standard output and expected bytes.

Previously, the built-in `assert_eq` does not show the difference between the left/right values by showing what characters are different from the other side. So, it was difficult for developers to figure out why tests fail.

From this motivation, I want to introduce `pretty_assertions`, which provides `assert_eq` with more colorful diffs.

See the following repository for more details about `pretty_assertions`.

https://github.com/rust-pretty-assertions/rust-pretty-assertions