### PR TITLE
Run `apt update` before `apt install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable, nightly]
     steps:
-      - run: sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - run: sudo apt-get update --yes && sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
         if: matrix.os == 'ubuntu-latest'
 
       - uses: actions/checkout@v4
@@ -52,4 +52,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/dependency-review-action@v3
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - run: sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev musl-tools
+      - run: sudo apt-get update --yes && sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev musl-tools
         if: matrix.os == 'ubuntu-latest'
 
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - run: sudo apt-get install libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - run: sudo apt-get update --yes && sudo apt-get install --yes --no-install-recommends libx11-xcb-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Recently, I got an error like this:

https://github.com/yykamei/thwack/actions/runs/6452098798/job/17546604788?pr=776

```
Err:2 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libx11-xcb-dev amd64 2:1.7.5-1ubuntu0.2
  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/libx/libx11/libx11-xcb-dev_1.7.5-1ubuntu0.2_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
Fetched 26.0 kB in 1s (42.6 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

I'm not sure how to fix this problem, but I want to try running `apt update` before `apt install`.