### PR TITLE
Use super-linter/super-linter instead of github/super-linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: github/super-linter@v5
+      - uses: super-linter/super-linter@v5
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to https://github.com/super-linter/super-linter/issues/4150, Super-Linter's ownership was transferred to @super-linter.