### PR TITLE
Add selected() in Candidates

### DIFF
--- a/src/candidates.rs
+++ b/src/candidates.rs
@@ -312,7 +312,10 @@ mod tests {
         assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");
 
         candidates.move_down();
-        assert_eq!(candidates.selected().unwrap().relative(), ".config/bar.toml");
+        assert_eq!(
+            candidates.selected().unwrap().relative(),
+            ".config/bar.toml"
+        );
 
         candidates.move_up();
         assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");

--- a/src/candidates.rs
+++ b/src/candidates.rs
@@ -312,10 +312,11 @@ mod tests {
         assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");
 
         candidates.move_down();
-        assert_eq!(
-            candidates.selected().unwrap().relative(),
-            ".config/bar.toml"
-        );
+        assert!(candidates
+            .selected()
+            .unwrap()
+            .relative()
+            .ends_with("bar.toml"));
 
         candidates.move_up();
         assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");

--- a/src/candidates.rs
+++ b/src/candidates.rs
@@ -47,6 +47,13 @@ impl Candidates {
         &self.paths[..min(self.visible_paths_length, self.paths.len())]
     }
 
+    pub(crate) fn selected(&self) -> Option<&MatchedPath> {
+        if let Some(selected) = self.selected {
+            return self.paths.get(selected);
+        }
+        None
+    }
+
     pub(crate) fn move_down(&mut self) {
         let limit = min(self.visible_paths_length, self.paths.len());
         if limit == 0 {
@@ -289,5 +296,25 @@ mod tests {
         assert_eq!(candidates.selected, None);
         candidates.move_up();
         assert_eq!(candidates.selected, None);
+    }
+
+    #[test]
+    fn test_selected() {
+        let dir = create_tree().unwrap();
+        let starting_point = StartingPoint::new(dir.path()).unwrap();
+        let query = Query::new("");
+        let repo = Repository::open(dir.path()).unwrap();
+        let mut candidates = Candidates::new(&starting_point, &query, Some(&repo)).unwrap();
+        candidates.visible_paths_length(3);
+        assert_eq!(candidates.selected(), None);
+
+        candidates.move_down();
+        assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");
+
+        candidates.move_down();
+        assert_eq!(candidates.selected().unwrap().relative(), ".config/bar.toml");
+
+        candidates.move_up();
+        assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");
     }
 }


### PR DESCRIPTION
The selected target will be used from the callers of `Candidates`.

This patch adds a new functionality to provide the selected target.