### PR TITLE
Make StatusLine derive Copy and Clone

### DIFF
--- a/src/status_line.rs
+++ b/src/status_line.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) enum StatusLine {
     Absolute,
     Relative,


### PR DESCRIPTION
`StatusLine` is so simple that I think this type should be copied/cloned for convenience.