### PR TITLE
Support CTRL-H, same as Backspace

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -462,7 +462,7 @@ impl From<Event> for ThwackEvent {
             Event::Key(event) => match event {
                 ctrl!('c') | esc!() => ThwackEvent::Quit,
                 char!(c) => ThwackEvent::QueryPush(c),
-                backspace!() => ThwackEvent::QueryPop,
+                backspace!() | ctrl!('h') => ThwackEvent::QueryPop,
                 up!() | ctrl!('p') => ThwackEvent::Up,
                 down!() | ctrl!('n') => ThwackEvent::Down,
                 left!() => ThwackEvent::Left,
@@ -593,6 +593,7 @@ mod tests {
             .add_event(Event::Key(KeyCode::Backspace.into()))
             .add_event(Event::Key(KeyCode::Backspace.into()))
             .add_event(Event::Key(KeyCode::Backspace.into()))
+            .add_event(Event::Key(ctrl!('h')))
             .add_event(Event::Key(KeyCode::Up.into()))
             .add_event(Event::Key(KeyCode::Up.into()))
             .add_event(Event::Key(KeyCode::Down.into()))


### PR DESCRIPTION
thwack has already supported the default Bash key binding (emacs) such as CTRL-P as Up and CTRL-N as Down. Now, I want to support CTRL-H as Backspace. I'm used to this key binding on shell terminal, so I want to use it on thwack, too.