### PR TITLE
Use Tree in Screen and Candidates

### DIFF
--- a/src/candidates.rs
+++ b/src/candidates.rs
@@ -1,11 +1,7 @@
-use std::fs::read_dir;
-use std::path::{Path, PathBuf};
-
-use git2::Repository;
-
 use crate::matched_path::MatchedPath;
 use crate::query::Query;
 use crate::starting_point::StartingPoint;
+use crate::tree::Tree;
 use crate::Result;
 
 #[derive(Debug)]
@@ -18,17 +14,16 @@ impl Candidates {
     pub(crate) fn new(
         visible_paths_length: usize,
         starting_point: &StartingPoint,
+        tree: &Tree,
         query: &Query,
-        repo: Option<&Repository>,
     ) -> Result<Self> {
         let mut paths: Vec<MatchedPath> = Vec::new();
-        extract_paths(
-            &mut paths,
-            starting_point,
-            starting_point.as_ref(),
-            query,
-            repo,
-        )?;
+        for path in tree.iter() {
+            match MatchedPath::new(&query.to_string(), starting_point.as_ref(), path) {
+                Some(matched) => paths.push(matched),
+                None => continue,
+            }
+        }
         paths.sort();
         paths.truncate(visible_paths_length);
         let selected = if paths.is_empty() { None } else { Some(0) };
@@ -74,122 +69,21 @@ impl Candidates {
     }
 }
 
-fn extract_paths<P: AsRef<Path>>(
-    paths: &mut Vec<MatchedPath>,
-    starting_point: &StartingPoint,
-    current_dir: P,
-    query: &Query,
-    repo: Option<&Repository>,
-) -> Result<()> {
-    for entry in read_dir(current_dir.as_ref())? {
-        let entry = entry?;
-        let path = entry.path();
-        if git_ignore(repo, &path) {
-            continue;
-        }
-        if path.is_dir() {
-            extract_paths(paths, starting_point, &path, query, repo)?;
-        } else {
-            if let Some(absolute) = path.to_str() {
-                match MatchedPath::new(&query.to_string(), starting_point.as_ref(), absolute) {
-                    Some(matched) => paths.push(matched),
-                    None => continue,
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn git_ignore(repo: Option<&Repository>, path: &PathBuf) -> bool {
-    if let Some(r) = repo {
-        match r.is_path_ignored(&path) {
-            Ok(result) => {
-                if result {
-                    return true;
-                }
-            }
-            Err(e) => {
-                log::error!("is_path_ignored failed: {:?}", e);
-                return true;
-            }
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
-    use std::fs::{create_dir_all, File};
-    use std::io;
-    use std::io::Write;
-
-    use git2::Signature;
-    use tempfile::{tempdir, TempDir};
-
     use super::*;
-
-    fn create_tree() -> io::Result<TempDir> {
-        let tmp = tempdir()?;
-        create_dir_all(tmp.path().join("src/a/b/c"))?;
-        create_dir_all(tmp.path().join("lib/a/b/c"))?;
-        create_dir_all(tmp.path().join(".config"))?;
-        let _ = File::create(tmp.path().join(".gitignore"))?.write_all(b"log.txt")?;
-        let _ = File::create(tmp.path().join("log.txt"))?;
-        let _ = File::create(tmp.path().join(".browserslistrc"))?;
-        let _ = File::create(tmp.path().join(".config/bar.toml"))?;
-        let _ = File::create(tmp.path().join(".config/ok.toml"))?;
-        let _ = File::create(tmp.path().join(".editorconfig"))?;
-        let _ = File::create(tmp.path().join(".env"))?;
-        let _ = File::create(tmp.path().join(".env.local"))?;
-        let _ = File::create(tmp.path().join(".npmrc"))?;
-        let _ = File::create(tmp.path().join(".nvmrc"))?;
-        let _ = File::create(tmp.path().join("Dockerfile"))?;
-        let _ = File::create(tmp.path().join("LICENSE"))?;
-        let _ = File::create(tmp.path().join("README.md"))?;
-        let _ = File::create(tmp.path().join("lib/a/b/c/index.js"))?;
-        let _ = File::create(tmp.path().join("lib/a/b/c/☕.js"))?;
-        let _ = File::create(tmp.path().join("lib/a/b/index.js"))?;
-        let _ = File::create(tmp.path().join("lib/a/index.js"))?;
-        let _ = File::create(tmp.path().join("lib/bar.js"))?;
-        let _ = File::create(tmp.path().join("lib/index.js"))?;
-        let _ = File::create(tmp.path().join("package-lock.json"))?;
-        let _ = File::create(tmp.path().join("package.json"))?;
-        let _ = File::create(tmp.path().join("src/a/__test__.js"))?;
-        let _ = File::create(tmp.path().join("src/a/b/c/index.js"))?;
-        let _ = File::create(tmp.path().join("src/a/b/index.js"))?;
-        let _ = File::create(tmp.path().join("src/a/index.js"))?;
-        let _ = File::create(tmp.path().join("src/a/☕.js"))?;
-        let _ = File::create(tmp.path().join("src/foo.js"))?;
-        let _ = File::create(tmp.path().join("src/index.js"))?;
-        let _ = File::create(tmp.path().join("tsconfig.json"))?;
-        let _ = File::create(tmp.path().join("☕.txt"))?;
-        // Prepare the Git repository
-        let repo = Repository::init(tmp.path()).unwrap();
-        let signature = Signature::now("test", "test@example.com").unwrap();
-        let tree = repo
-            .find_tree(repo.index().unwrap().write_tree().unwrap())
-            .unwrap();
-        let _ = repo
-            .commit(
-                Some("HEAD"),
-                &signature,
-                &signature,
-                "Initial commit",
-                &tree,
-                &[],
-            )
-            .unwrap();
-        Ok(tmp)
-    }
+    use crate::tree::tests::create_files;
+    use git2::Repository;
 
     #[test]
     fn test_candidates_without_query() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("");
         let repo = Repository::open(dir.path()).unwrap();
-        let candidates = Candidates::new(3, &starting_point, &query, Some(&repo)).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), Some(&repo)).unwrap();
+
+        let candidates = Candidates::new(3, &starting_point, &tree, &query).unwrap();
         let result: Vec<String> = candidates
             .paths
             .iter()
@@ -204,11 +98,12 @@ mod tests {
 
     #[test]
     fn test_candidates_with_query() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("bar");
         let repo = Repository::open(dir.path()).unwrap();
-        let candidates = Candidates::new(5, &starting_point, &query, Some(&repo)).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), Some(&repo)).unwrap();
+        let candidates = Candidates::new(5, &starting_point, &tree, &query).unwrap();
         let result: Vec<String> = candidates
             .paths
             .iter()
@@ -220,10 +115,12 @@ mod tests {
 
     #[test]
     fn test_candidates_without_repo() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("");
-        let candidates = Candidates::new(100, &starting_point, &query, None).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), None).unwrap();
+
+        let candidates = Candidates::new(100, &starting_point, &tree, &query).unwrap();
         let result: Vec<String> = candidates
             .paths
             .iter()
@@ -236,11 +133,13 @@ mod tests {
 
     #[test]
     fn test_move_down() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("");
         let repo = Repository::open(dir.path()).unwrap();
-        let mut candidates = Candidates::new(3, &starting_point, &query, Some(&repo)).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), Some(&repo)).unwrap();
+
+        let mut candidates = Candidates::new(3, &starting_point, &tree, &query).unwrap();
         assert_eq!(candidates.selected, Some(0));
         candidates.move_down();
         assert_eq!(candidates.selected, Some(1));
@@ -251,7 +150,7 @@ mod tests {
         candidates.move_down();
         assert_eq!(candidates.selected, Some(2));
 
-        let mut candidates = Candidates::new(0, &starting_point, &query, Some(&repo)).unwrap();
+        let mut candidates = Candidates::new(0, &starting_point, &tree, &query).unwrap();
         candidates.move_down();
         assert_eq!(candidates.selected, None);
         candidates.move_down();
@@ -260,11 +159,13 @@ mod tests {
 
     #[test]
     fn test_move_up() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("");
         let repo = Repository::open(dir.path()).unwrap();
-        let mut candidates = Candidates::new(3, &starting_point, &query, Some(&repo)).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), Some(&repo)).unwrap();
+
+        let mut candidates = Candidates::new(3, &starting_point, &tree, &query).unwrap();
         assert_eq!(candidates.selected, Some(0));
         candidates.move_up();
         assert_eq!(candidates.selected, Some(0));
@@ -279,7 +180,7 @@ mod tests {
         candidates.move_up();
         assert_eq!(candidates.selected, Some(0));
 
-        let mut candidates = Candidates::new(0, &starting_point, &query, Some(&repo)).unwrap();
+        let mut candidates = Candidates::new(0, &starting_point, &tree, &query).unwrap();
         candidates.move_up();
         assert_eq!(candidates.selected, None);
         candidates.move_up();
@@ -288,11 +189,13 @@ mod tests {
 
     #[test]
     fn test_selected() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("");
         let repo = Repository::open(dir.path()).unwrap();
-        let mut candidates = Candidates::new(3, &starting_point, &query, Some(&repo)).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), Some(&repo)).unwrap();
+
+        let mut candidates = Candidates::new(3, &starting_point, &tree, &query).unwrap();
         assert_eq!(candidates.selected().unwrap().relative(), ".browserslistrc");
 
         candidates.move_down();
@@ -316,10 +219,12 @@ mod tests {
 
     #[test]
     fn test_selected_none_at_started() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(false).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("ABCABC!!!!!!!!!");
-        let mut candidates = Candidates::new(3, &starting_point, &query, None).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), None).unwrap();
+
+        let mut candidates = Candidates::new(3, &starting_point, &tree, &query).unwrap();
         assert_eq!(candidates.selected(), None);
 
         candidates.move_down();
@@ -330,11 +235,13 @@ mod tests {
 
     #[test]
     fn test_paths() {
-        let dir = create_tree().unwrap();
+        let dir = create_files(true).unwrap();
         let starting_point = StartingPoint::new(dir.path()).unwrap();
         let query = Query::new("");
         let repo = Repository::open(dir.path()).unwrap();
-        let candidates = Candidates::new(3, &starting_point, &query, Some(&repo)).unwrap();
+        let tree = Tree::new(starting_point.as_ref(), Some(&repo)).unwrap();
+
+        let candidates = Candidates::new(3, &starting_point, &tree, &query).unwrap();
         let result: Vec<String> = candidates
             .paths()
             .iter()

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -16,6 +16,7 @@ use crate::preferences::Preferences;
 use crate::query::Query;
 use crate::starting_point::StartingPoint;
 use crate::status_line::StatusLine;
+use crate::tree::Tree;
 use crate::{Error, Terminal};
 
 macro_rules! ctrl {
@@ -129,6 +130,7 @@ pub(crate) struct Screen<'a, T: Terminal, W: Write> {
     query: Query,
     starting_point: StartingPoint,
     repo: Option<Repository>,
+    tree: Tree,
     candidates: Candidates,
     clipboard: Option<ClipboardContext>,
     terminal: &'a T,
@@ -158,7 +160,8 @@ impl<'a, T: Terminal, W: Write> Screen<'a, T, W> {
         } else {
             None
         };
-        let candidates = Candidates::new(visible, &starting_point, &query, repo.as_ref())?;
+        let tree = Tree::new(starting_point.as_ref(), repo.as_ref())?;
+        let candidates = Candidates::new(visible, &starting_point, &tree, &query)?;
         let clipboard = match ClipboardContext::new().map_err(|e| Error::clipboard(e)) {
             Ok(c) => Some(c),
             Err(e) => {
@@ -172,6 +175,7 @@ impl<'a, T: Terminal, W: Write> Screen<'a, T, W> {
             query,
             starting_point,
             repo,
+            tree,
             candidates,
             clipboard,
             terminal,
@@ -216,8 +220,8 @@ impl<'a, T: Terminal, W: Write> Screen<'a, T, W> {
                     self.candidates = Candidates::new(
                         visible_paths_length(self.terminal, &self.preferences)?,
                         &self.starting_point,
+                        &self.tree,
                         &self.query,
-                        self.repo.as_ref(),
                     )?;
                     self.render()?;
                 }
@@ -226,8 +230,8 @@ impl<'a, T: Terminal, W: Write> Screen<'a, T, W> {
                     self.candidates = Candidates::new(
                         visible_paths_length(self.terminal, &self.preferences)?,
                         &self.starting_point,
+                        &self.tree,
                         &self.query,
-                        self.repo.as_ref(),
                     )?;
                     self.render()?;
                 }
@@ -281,8 +285,8 @@ impl<'a, T: Terminal, W: Write> Screen<'a, T, W> {
                     self.candidates = Candidates::new(
                         visible_paths_length(self.terminal, &self.preferences)?,
                         &self.starting_point,
+                        &self.tree,
                         &self.query,
-                        self.repo.as_ref(),
                     )?;
                     self.render()?;
                 }


### PR DESCRIPTION
In the previous pull request below, `Tree` has been introduced in this repository to store the all files under the `starting_point`.

https://github.com/yykamei/thwack/pull/1059

This patch uses `Tree` in `Screen` and `Candidates` to reduce I/O of getting files.