### PR TITLE
Update the Ord impl for `MatchedPath`

### DIFF
--- a/src/candidates.rs
+++ b/src/candidates.rs
@@ -90,10 +90,7 @@ mod tests {
             .map(|p| p.relative())
             .map(|m| format!("{}", m).replace('\\', "/"))
             .collect();
-        assert_eq!(
-            result,
-            &[".browserslistrc", ".config/bar.toml", ".config/ok.toml"]
-        );
+        assert_eq!(result, &[".browserslistrc", ".editorconfig", ".env"]);
     }
 
     #[test]
@@ -203,14 +200,10 @@ mod tests {
             .selected()
             .unwrap()
             .relative()
-            .ends_with("bar.toml"));
+            .ends_with(".editorconfig"));
 
         candidates.move_down();
-        assert!(candidates
-            .selected()
-            .unwrap()
-            .relative()
-            .ends_with("ok.toml"));
+        assert!(candidates.selected().unwrap().relative().ends_with(".env"));
 
         candidates.move_up();
         candidates.move_up();
@@ -248,9 +241,6 @@ mod tests {
             .map(|p| p.relative())
             .map(|m| format!("{}", m).replace('\\', "/"))
             .collect();
-        assert_eq!(
-            result,
-            &[".browserslistrc", ".config/bar.toml", ".config/ok.toml"]
-        );
+        assert_eq!(result, &[".browserslistrc", ".editorconfig", ".env"]);
     }
 }

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -163,7 +163,7 @@ impl MatchLevel {
                 MatchLevel::Approximate
             };
         }
-        if query == relative || relative.contains(normalize_query(&format!("/{}", query))) {
+        if query == relative || relative.contains(&normalize_query(&format!("/{}", query))) {
             MatchLevel::Exact
         } else if relative.contains(&query) {
             MatchLevel::Partial

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -154,7 +154,7 @@ impl MatchLevel {
         }
 
         let query = query.to_lowercase();
-        let relative = relative.to_lowercase();
+        let relative = normalize_query(relative).to_lowercase();
 
         if query.starts_with(&['/', '\\'][..]) {
             return if relative.contains(&query) {
@@ -312,6 +312,17 @@ mod tests {
                 relative: String::from("abc/abc/abc.txt"),
                 absolute_positions: vec![9, 10, 11, 12, 13, 14, 15],
                 relative_positions: vec![8, 9, 10, 11, 12, 13, 14],
+                depth: 2,
+                level: MatchLevel::Exact,
+            },
+        );
+        assert_eq!(
+            new("/abc.txt", "/", "/abc/abc/abc.txt"),
+            MatchedPath {
+                absolute: String::from("/abc/abc/abc.txt"),
+                relative: String::from("abc/abc/abc.txt"),
+                absolute_positions: vec![8, 9, 10, 11, 12, 13, 14, 15],
+                relative_positions: vec![7, 8, 9, 10, 11, 12, 13, 14],
                 depth: 2,
                 level: MatchLevel::Exact,
             },

--- a/src/matched_path.rs
+++ b/src/matched_path.rs
@@ -317,17 +317,6 @@ mod tests {
             },
         );
         assert_eq!(
-            new("/abc.txt", "/", "/abc/abc/abc.txt"),
-            MatchedPath {
-                absolute: String::from("/abc/abc/abc.txt"),
-                relative: String::from("abc/abc/abc.txt"),
-                absolute_positions: vec![8, 9, 10, 11, 12, 13, 14, 15],
-                relative_positions: vec![7, 8, 9, 10, 11, 12, 13, 14],
-                depth: 2,
-                level: MatchLevel::Exact,
-            },
-        );
-        assert_eq!(
             new("", "/", "/abc/abc/abc.txt"),
             MatchedPath {
                 absolute: String::from("/abc/abc/abc.txt"),

--- a/src/query.rs
+++ b/src/query.rs
@@ -24,7 +24,7 @@ impl Query {
         Self {
             value,
             idx,
-            terminal_pos: terminal_pos,
+            terminal_pos,
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -33,10 +33,8 @@ fn extract_paths<P: AsRef<Path>>(
         }
         if path.is_dir() {
             extract_paths(paths, &path, repo)?;
-        } else {
-            if let Some(absolute) = path.to_str() {
-                paths.push(absolute.to_string());
-            }
+        } else if let Some(absolute) = path.to_str() {
+            paths.push(absolute.to_string());
         }
     }
     Ok(())


### PR DESCRIPTION
Previously, the result of `sort` for `MatchedPath` was odd. For example, if I put "user.rb" in `query`, I got `lib/admin_user.rb` first, instead of `lib/user.rb`. I expected `lib/user.rb` should be prioritized over `lib/admin_user.rb` because `lib/user.rb` exactly matched in the basename of the path.

That's why I updated `Ord` impl for `MatchedPath`.