### PR TITLE
Support Ctrl-R to reload the file tree

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -290,6 +290,17 @@ impl<'a, T: Terminal, W: Write> Screen<'a, T, W> {
                     )?;
                     self.render()?;
                 }
+                ThwackEvent::Reload => {
+                    self.tree = Tree::new(self.starting_point.as_ref(), self.repo.as_ref())?;
+                    self.candidates = Candidates::new(
+                        visible_paths_length(self.terminal, &self.preferences)?,
+                        &self.starting_point,
+                        &self.tree,
+                        &self.query,
+                    )?;
+                    // TODO: Feedback to the user when the tree is reloaded.
+                    self.render()?;
+                }
                 ThwackEvent::None => {}
             }
         }
@@ -457,6 +468,7 @@ enum ThwackEvent {
     CopyAbsolutePath,
     CopyRelativePath,
     TerminalResize,
+    Reload,
     None,
 }
 
@@ -474,6 +486,7 @@ impl From<Event> for ThwackEvent {
                 enter!() => ThwackEvent::Invoke,
                 ctrl!('y') => ThwackEvent::CopyAbsolutePath,
                 ctrl!('d') => ThwackEvent::CopyRelativePath,
+                ctrl!('r') => ThwackEvent::Reload,
                 _ => ThwackEvent::None,
             },
             Event::Resize(_, _) => ThwackEvent::TerminalResize,


### PR DESCRIPTION
Although the current thwack implementation loads file tree in memory at the beginning of this program, sometimes a user might want to reload the file tree for some reason. I think it's worth adding a new feature to reload the file tree when the user commands to reload it.

This patch allows a user to reload the file tree when the user type Ctrl-R.